### PR TITLE
feat:관리자-강사회원가입

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminInstructorController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminInstructorController.java
@@ -1,0 +1,45 @@
+package com.wanted.ailienlmsprogram.admin.controller;
+
+import com.wanted.ailienlmsprogram.admin.dto.AdminInstructorCreateRequest;
+import com.wanted.ailienlmsprogram.admin.service.AdminInstructorService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin/instructors")
+public class AdminInstructorController {
+
+    private final AdminInstructorService adminInstructorService;
+
+    @GetMapping("/new")
+    public String newInstructorPage(Model model) {
+        if (!model.containsAttribute("request")) {
+            model.addAttribute("request", new AdminInstructorCreateRequest());
+        }
+        return "admin/instructor-create";
+    }
+
+    @PostMapping("/new")
+    public String createInstructor(
+            @Valid @ModelAttribute("request") AdminInstructorCreateRequest request,
+            BindingResult bindingResult,
+            Model model
+    ) {
+        if (bindingResult.hasErrors()) {
+            return "admin/instructor-create";
+        }
+
+        try {
+            adminInstructorService.createInstructor(request);
+            return "redirect:/admin?createdInstructor=true";
+        } catch (IllegalArgumentException e) {
+            model.addAttribute("errorMessage", e.getMessage());
+            return "admin/instructor-create";
+        }
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminInstructorCreateRequest.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminInstructorCreateRequest.java
@@ -1,0 +1,25 @@
+package com.wanted.ailienlmsprogram.admin.dto;
+
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AdminInstructorCreateRequest {
+
+    @NotBlank(message = "아이디는 필수입니다.")
+    private String loginId;
+
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @NotBlank(message = "이메일은 필수입니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+
+    @NotBlank(message = "이름은 필수입니다.")
+    private String name;
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminInstructorService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminInstructorService.java
@@ -1,0 +1,51 @@
+package com.wanted.ailienlmsprogram.admin.service;
+
+import com.wanted.ailienlmsprogram.admin.dto.AdminInstructorCreateRequest;
+import com.wanted.ailienlmsprogram.member.entity.Member;
+import com.wanted.ailienlmsprogram.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class AdminInstructorService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void createInstructor(AdminInstructorCreateRequest request) {
+        validateDuplicate(request);
+
+        Member member = new Member();
+        member.setLoginId(request.getLoginId());
+        member.setEmail(request.getEmail());
+        member.setPassword(passwordEncoder.encode(request.getPassword()));
+        member.setName(request.getName());
+
+        member.setRole(Member.MemberRole.INSTRUCTOR);
+        member.setAccountStatus(Member.AccountStatus.ACTIVE);
+
+        member.setCreatedAt(LocalDateTime.now());
+        member.setUpdatedAt(LocalDateTime.now());
+
+        // nullable 컬럼은 세팅하지 않음
+        // phone, profileImageUrl, introduction, deletedAt, rank, lastLoginAt
+
+        memberRepository.save(member);
+    }
+
+    private void validateDuplicate(AdminInstructorCreateRequest request) {
+        if (memberRepository.existsByLoginId(request.getLoginId())) {
+            throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
+        }
+
+        if (memberRepository.existsByEmail(request.getEmail())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
     url: jdbc:mysql://localhost:3306/module02_lms
-    username: module02
-    password: module02
+    username: Alien
+    password: Alien
 
   jpa:
     hibernate:

--- a/src/main/resources/templates/admin/instructor-create.html
+++ b/src/main/resources/templates/admin/instructor-create.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>강사 계정 생성</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background: #0b1020;
+            color: #f5f7ff;
+            margin: 0;
+            padding: 40px 20px;
+        }
+
+        .container {
+            max-width: 720px;
+            margin: 0 auto;
+            background: #151c33;
+            border-radius: 16px;
+            padding: 32px;
+            box-shadow: 0 12px 40px rgba(0,0,0,0.35);
+        }
+
+        h1 {
+            margin-top: 0;
+        }
+
+        .desc {
+            color: #b8c2e0;
+            margin-bottom: 24px;
+        }
+
+        .alert {
+            padding: 12px 16px;
+            border-radius: 10px;
+            margin-bottom: 16px;
+        }
+
+        .alert-error {
+            background: #3a1620;
+            color: #ffb3c1;
+        }
+
+        .field {
+            margin-bottom: 18px;
+        }
+
+        label {
+            display: block;
+            margin-bottom: 8px;
+            font-weight: bold;
+        }
+
+        input {
+            width: 100%;
+            padding: 12px;
+            border-radius: 10px;
+            border: 1px solid #39456f;
+            background: #0f1529;
+            color: white;
+            box-sizing: border-box;
+        }
+
+        .error {
+            margin-top: 6px;
+            font-size: 14px;
+            color: #ff9cae;
+        }
+
+        .actions {
+            display: flex;
+            gap: 12px;
+            margin-top: 24px;
+        }
+
+        .btn {
+            display: inline-block;
+            padding: 12px 18px;
+            border-radius: 10px;
+            text-decoration: none;
+            border: none;
+            cursor: pointer;
+            font-weight: bold;
+        }
+
+        .btn-primary {
+            background: #ff8f3d;
+            color: #111;
+        }
+
+        .btn-secondary {
+            background: #2d375b;
+            color: white;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>강사 계정 생성</h1>
+    <p class="desc">
+        관리자가 강사 기본 계정을 먼저 생성합니다.
+        전화번호, 소개, 프로필 이미지는 이후 강사 개인 정보 수정에서 입력합니다.
+    </p>
+
+    <div th:if="${errorMessage}" class="alert alert-error" th:text="${errorMessage}"></div>
+
+    <form th:action="@{/admin/instructors/new}" th:object="${request}" method="post">
+        <div class="field">
+            <label for="loginId">아이디</label>
+            <input id="loginId" type="text" th:field="*{loginId}">
+            <div class="error" th:if="${#fields.hasErrors('loginId')}" th:errors="*{loginId}"></div>
+        </div>
+
+        <div class="field">
+            <label for="email">이메일</label>
+            <input id="email" type="email" th:field="*{email}">
+            <div class="error" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></div>
+        </div>
+
+        <div class="field">
+            <label for="password">비밀번호</label>
+            <input id="password" type="password" th:field="*{password}">
+            <div class="error" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></div>
+        </div>
+
+        <div class="field">
+            <label for="name">이름</label>
+            <input id="name" type="text" th:field="*{name}">
+            <div class="error" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></div>
+        </div>
+
+        <div class="actions">
+            <button type="submit" class="btn btn-primary">강사 계정 생성</button>
+            <a th:href="@{/admin}" class="btn btn-secondary">관리자 홈으로</a>
+        </div>
+    </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 관련 이슈
Closes #25

## 작업 브랜치
- ex) feat/admin-instructor-account

## 작업 목적
- 관리자의 강사 계정 생성 기능 구현

## 변경 사항
- admin 패키지 추가
- controller, dto, service 클래스 생성
- entity는 member 패키지에 있는 member 엔티티 사용


## 테스트 내용
- 강사계정생성
- 강사계정 로그인

