### PR TITLE
fix: 등급하락 로직 개선

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/global/security/SecurityLoginSuccessHandler.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/global/security/SecurityLoginSuccessHandler.java
@@ -1,9 +1,11 @@
 package com.wanted.ailienlmsprogram.global.security;
 
+import com.wanted.ailienlmsprogram.member.service.MemberService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -11,17 +13,24 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class SecurityLoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final MemberService memberService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
 
+
+
         HttpSession session = request.getSession();
         session.setMaxInactiveInterval(86400);
 
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        memberService.handleLoginSuccess(userDetails.getMember().getMemberId());
 
         if (userDetails.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))) {
             response.sendRedirect("/admin");

--- a/src/main/java/com/wanted/ailienlmsprogram/member/service/MemberService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/member/service/MemberService.java
@@ -37,11 +37,12 @@ public class MemberService {
         member.setRole(Member.MemberRole.STUDENT);
         member.setAccountStatus(Member.AccountStatus.ACTIVE);
 
-        // 정책 반영
+        // 첫 회원가입 등급
         member.setRank(Member.MemberRank.REPTILIAN);
 
-        member.setCreatedAt(LocalDateTime.now());
-        member.setUpdatedAt(LocalDateTime.now());
+        LocalDateTime now = LocalDateTime.now();
+        member.setCreatedAt(now);
+        member.setUpdatedAt(now);
 
         memberRepository.save(member);
     }
@@ -52,8 +53,11 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
 
         LocalDateTime now = LocalDateTime.now();
+
+        // 로그인 시점에는 승급 없음, 강등만 판단
         applyRankPolicy(member, now);
 
+        // 관리자 조회 및 다음 로그인 기준 시점 갱신
         member.setLastLoginAt(now);
         member.setUpdatedAt(now);
     }
@@ -61,19 +65,21 @@ public class MemberService {
     private void applyRankPolicy(Member member, LocalDateTime now) {
         LocalDateTime lastLoginAt = member.getLastLoginAt();
 
-        // 첫 로그인 또는 이전 로그인 기록이 없으면 기본 등급 유지
+        // 첫 로그인이라면 강등 없이 현재 등급 유지
         if (lastLoginAt == null) {
             return;
         }
 
         long inactiveDays = Duration.between(lastLoginAt, now).toDays();
 
+        // 7일 이상 미로그인 -> NOVICE
         if (inactiveDays >= 7) {
             member.setRank(Member.MemberRank.NOVICE);
             return;
         }
 
-        if (inactiveDays >= 3 && member.getRank() == Member.MemberRank.REPTILIAN) {
+        // 3일 이상 7일 미만 미로그인 -> MINERVAL
+        if (inactiveDays >= 3) {
             member.setRank(Member.MemberRank.MINERVAL);
         }
     }


### PR DESCRIPTION
## 관련 이슈
Closes #38

## 작업 브랜치
- fix/login-rank

## 작업 목적
- 로그인/등급 관련 정책 개선

## 변경 사항
SecuritySuccessHandler
MemberService

### 상세 변경 내용
1. handleLoginSuccess(memberId)를 호출
2. 주석과 메서드 의미를 정책 의미와 맞게 수정

## 테스트 내용
- [ ] 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] 로컬 실행 확인

