### PR TITLE
refactor: 학생 로그인 시 대륙탐색 페이지로 리다이렉트

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/global/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/global/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/login", "/signup", "/access-denied", "/continents", "/continents/*").permitAll()
                         .requestMatchers("/continents/*/posts", "/courses/*").authenticated()
+                        .requestMatchers("main").hasRole("STUDENT")
                         .requestMatchers("/student/**").hasRole("STUDENT")
                         .requestMatchers("/instructor/**").hasRole("INSTRUCTOR")
                         .requestMatchers("/admin/**").hasRole("ADMIN")

--- a/src/main/java/com/wanted/ailienlmsprogram/global/security/SecurityLoginSuccessHandler.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/global/security/SecurityLoginSuccessHandler.java
@@ -40,6 +40,6 @@ public class SecurityLoginSuccessHandler implements AuthenticationSuccessHandler
             return;
         }
 
-        response.sendRedirect("/student");
+        response.sendRedirect("/main");
     }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/member/controller/PageController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/member/controller/PageController.java
@@ -1,14 +1,30 @@
 package com.wanted.ailienlmsprogram.member.controller;
 
+import com.wanted.ailienlmsprogram.continent.service.ContinentService;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class PageController {
 
+    private final ContinentService continentService;
+
+    public PageController(ContinentService continentService) {
+        this.continentService = continentService;
+    }
+
     @GetMapping("/access-denied")
     public String accessDeniedPage() {
         return "common/access-denied";
+    }
+
+    @GetMapping("/main")
+    public String mainPage(@RequestParam(required = false) String query, Model model){
+        model.addAttribute("continents",continentService.findAllContinents(query));
+        model.addAttribute("query", query);
+        return "home/index";
     }
 
     @GetMapping("/student")


### PR DESCRIPTION
## 관련 이슈
Closes #56 

## 작업 브랜치
- refactor/session-first-page

## 작업 목적
- 학생 로그인 시 자동으로 student-home으로 get하는 구조를, 대륙 탐색 페이지로 redirect 할 수 있도록 구조 개선

## 변경 사항
- SecurityLoginSuccessHandler.java
-  PageController.java
-  SecurityConfig에 /main 권한 명시

### 상세 변경 내용
1. SecurityLoginSuccessHandler 마지막 분기를 /student에서 /main으로
2. pageController에서 /main getmapping 메소드 추가
3. SecurityConfig에 /main 권한 명시(학생만 허용)

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

