### PR TITLE
feat:관리자 환불 관리

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminInstructorController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminInstructorController.java
@@ -9,6 +9,12 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
+
+/*관리자 강사 계쩡 생성 기능을 담당하는 컨트롤러
+*
+* - 강사 계정 생성 화면을 조회한다.
+* - 강사 계정 생성 요청을 받아 서비스에 위임한다.
+* - 입력값 검증 실패 또는 중복 데이터 예외 발생 시 생성 폼으로 다시 이동시킨다.*/
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/admin/instructors")
@@ -16,6 +22,7 @@ public class AdminInstructorController {
 
     private final AdminInstructorService adminInstructorService;
 
+    //강사 계정 생성 페이지를 조회한다.
     @GetMapping("/new")
     public String newInstructorPage(Model model) {
         if (!model.containsAttribute("request")) {
@@ -24,16 +31,19 @@ public class AdminInstructorController {
         return "admin/instructor-create";
     }
 
+    //강사 계정 생성 요청을 처리한다.
     @PostMapping("/new")
     public String createInstructor(
             @Valid @ModelAttribute("request") AdminInstructorCreateRequest request,
             BindingResult bindingResult,
             Model model
     ) {
+        // 검증 오류가 있으면 생성 페이지로 다시 이동한다.
         if (bindingResult.hasErrors()) {
             return "admin/instructor-create";
         }
-
+        //정상 입력이면 서비스에 강사 계정 생성을 위임한다.
+        //중복 아이디/이메일 등 비즈니스 예외 발생 시 에러 메시지를 모델에 담아 반환한다.
         try {
             adminInstructorService.createInstructor(request);
             return "redirect:/admin?createdInstructor=true";

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminMemberController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminMemberController.java
@@ -9,6 +9,12 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+/*관리자 회원 관리 기능을 담당하는 컨트롤러
+*
+* - 회원 목록 및 검색 결과를 조회한다.
+* - 회원 상태를 변경한다.
+* - 회원 삭제 요청을 처리한다.
+* - 처리 후 기존 검색 조건을 유지한 채 목록 화면으로 리다이렉트한다.*/
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/admin/members")
@@ -16,6 +22,7 @@ public class AdminMemberController {
 
     private final AdminMemberService adminMemberService;
 
+    //회원 목록 화면을 조회한다.
     @GetMapping
     public String memberList(@ModelAttribute("condition") AdminMemberSearchCondition condition,
                              Model model) {
@@ -24,6 +31,7 @@ public class AdminMemberController {
         return "admin/member-list";
     }
 
+    //특정 회원의 상태를 토글한다.
     @PostMapping("/{memberId}/toggle-status")
     public String toggleStatus(@PathVariable Long memberId,
                                @RequestParam(required = false) String query,
@@ -46,6 +54,7 @@ public class AdminMemberController {
         return "redirect:/admin/members";
     }
 
+    //특정 회원을 삭제처리한다.
     @PostMapping("/{memberId}/delete")
     public String delete(@PathVariable Long memberId,
                          @RequestParam(required = false) String query,

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminRefundController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminRefundController.java
@@ -1,11 +1,13 @@
 package com.wanted.ailienlmsprogram.admin.controller;
 
 import com.wanted.ailienlmsprogram.admin.service.AdminRefundService;
+import com.wanted.ailienlmsprogram.payment.entity.Refund;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
@@ -16,23 +18,35 @@ public class AdminRefundController {
     private final AdminRefundService adminRefundService;
 
     @PostMapping("/{refundId}/approve")
-    public String approve(@PathVariable Long refundId, RedirectAttributes ra) {
+    public String approve(@PathVariable Long refundId,
+                          @RequestParam(required = false) Refund.RefundStatus status,
+                          RedirectAttributes ra) {
         try {
             adminRefundService.approveRefund(refundId);
             ra.addFlashAttribute("successMsg", "환불이 승인되었습니다.");
         } catch (IllegalArgumentException e) {
             ra.addFlashAttribute("errorMsg", e.getMessage());
         }
+
+        if (status != null) {
+            ra.addAttribute("status", status);
+        }
         return "redirect:/admin/refunds";
     }
 
     @PostMapping("/{refundId}/reject")
-    public String reject(@PathVariable Long refundId, RedirectAttributes ra) {
+    public String reject(@PathVariable Long refundId,
+                         @RequestParam(required = false) Refund.RefundStatus status,
+                         RedirectAttributes ra) {
         try {
             adminRefundService.rejectRefund(refundId);
             ra.addFlashAttribute("successMsg", "환불이 거절되었습니다.");
         } catch (IllegalArgumentException e) {
             ra.addFlashAttribute("errorMsg", e.getMessage());
+        }
+
+        if (status != null) {
+            ra.addAttribute("status", status);
         }
         return "redirect:/admin/refunds";
     }

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminRefundPageController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminRefundPageController.java
@@ -1,0 +1,29 @@
+package com.wanted.ailienlmsprogram.admin.controller;
+
+import com.wanted.ailienlmsprogram.admin.service.AdminRefundService;
+import com.wanted.ailienlmsprogram.payment.entity.Refund;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/* /admin/refunds 전용 컨트롤러 추가
+* refund 목록 조회*/
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin/refunds")
+public class AdminRefundPageController {
+
+    private final AdminRefundService adminRefundService;
+
+    @GetMapping
+    public String refundList(@RequestParam(required = false) Refund.RefundStatus status,
+            Model model){
+        model.addAttribute("refunds",adminRefundService.getRefunds(status));
+        model.addAttribute("selectedStatus",status);
+        model.addAttribute("refundStatus",Refund.RefundStatus.values());
+        return "admin/refund-list";
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminInstructorCreateRequest.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminInstructorCreateRequest.java
@@ -6,6 +6,10 @@ import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
+/*관리자 강사 계정 생성 요청 데이터를 담는 DTO
+*
+* - 강사 생성 폼에서 입력받은 아이디, 이메일, 비밀번호, 이름을 전달하며,
+* - Bean Validation을 통해 필수값 및 이메일 형식을 검증한다.*/
 @Getter
 @Setter
 public class AdminInstructorCreateRequest {

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminMemberListResponse.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminMemberListResponse.java
@@ -6,6 +6,10 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+/*관리자 회원 목록 화면에 필요한 데이터를 담는 응답 DTO.
+*
+* - 회원 기본 정보를 계쩡 상태를 포함하며,
+* - 화면 표시를 돕기 위한 상태 문자열/버튼 활성화 관련 메소드를 제공한다.*/
 @Getter
 @AllArgsConstructor
 public class AdminMemberListResponse {
@@ -22,20 +26,6 @@ public class AdminMemberListResponse {
     private Member.AccountStatus accountStatus;
     private LocalDateTime bannedAt;
 
-    public String getDisplayStatus() {
-        return switch (accountStatus) {
-            case ACTIVE -> "활성";
-            case BANNED, INACTIVE -> "제재";
-        };
-    }
-
-    public boolean canToggleStatus() {
-        return role != Member.MemberRole.ADMIN;
-    }
-
-    public String getActionLabel() {
-        return accountStatus == Member.AccountStatus.ACTIVE ? "제재" : "제재 해제";
-    }
 
 
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminMemberSearchCondition.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminMemberSearchCondition.java
@@ -4,6 +4,10 @@ import com.wanted.ailienlmsprogram.member.entity.Member;
 import lombok.Getter;
 import lombok.Setter;
 
+/*관리자 회원 목록 검색 조건을 담는 DTO
+*
+* - query: 아이디,이름,이메일 검색어
+* - role: 회원 역할 필터*/
 @Getter
 @Setter
 public class AdminMemberSearchCondition {

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminRefundListResponse.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminRefundListResponse.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 public class AdminRefundListResponse {
 
     private Long refundId;
-    private Long paymentId;
     private String paymentOrderNo;
     private Integer paymentTotalPrice;
 
@@ -30,7 +29,6 @@ public class AdminRefundListResponse {
 
         return new AdminRefundListResponse(
                 refund.getRefundId(),
-                payment.getPaymentId(),
                 payment.getPaymentOrderNo(),
                 payment.getPaymentTotalPrice(),
                 refund.getMember().getMemberId(),

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminRefundListResponse.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminRefundListResponse.java
@@ -1,0 +1,57 @@
+package com.wanted.ailienlmsprogram.admin.dto;
+
+import com.wanted.ailienlmsprogram.payment.entity.Payment;
+import com.wanted.ailienlmsprogram.payment.entity.Refund;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class AdminRefundListResponse {
+
+    private Long refundId;
+    private Long paymentId;
+    private String paymentOrderNo;
+    private Integer paymentTotalPrice;
+
+    private Long memberId;
+    private String memberLoginId;
+    private String memberName;
+
+    private String refundReason;
+    private Refund.RefundStatus refundStatus;
+    private LocalDateTime refundRequestedAt;
+    private LocalDateTime refundProcessedAt;
+
+    public static AdminRefundListResponse from(Refund refund) {
+        Payment payment = refund.getPayment();
+
+        return new AdminRefundListResponse(
+                refund.getRefundId(),
+                payment.getPaymentId(),
+                payment.getPaymentOrderNo(),
+                payment.getPaymentTotalPrice(),
+                refund.getMember().getMemberId(),
+                refund.getMember().getLoginId(),
+                refund.getMember().getName(),
+                refund.getRefundReason(),
+                refund.getRefundStatus(),
+                refund.getRefundRequestedAt(),
+                refund.getRefundProcessedAt()
+        );
+    }
+
+    public boolean isRequested() {
+        return refundStatus == Refund.RefundStatus.REQUESTED;
+    }
+
+    public String getDisplayStatus() {
+        return switch (refundStatus) {
+            case REQUESTED -> "처리 대기";
+            case APPROVED -> "승인 완료";
+            case REJECTED -> "거절 완료";
+        };
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminMemberQueryRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminMemberQueryRepository.java
@@ -11,12 +11,18 @@ import org.springframework.util.StringUtils;
 
 import java.util.List;
 
+/*관리자 회원 조회 전용 쿼리 리포지토리.
+*
+* - 검색 조건에 따라 JPQL을 동적으로 생성한다.
+* - 회원 목록 화면에 필요한 데이터만 DTO로 조회한다.
+* - 회원 단건 조회 기능을 제공한다.*/
 @Repository
 public class AdminMemberQueryRepository {
 
     @PersistenceContext
     private EntityManager em;
 
+    //검색 조건에 맞는 회원 목록을 조회한다.
     public List<AdminMemberListResponse> findMembers(AdminMemberSearchCondition condition) {
         StringBuilder jpql = new StringBuilder("""
             select new com.wanted.ailienlmsprogram.admin.dto.AdminMemberListResponse(
@@ -65,6 +71,7 @@ public class AdminMemberQueryRepository {
         return query.getResultList();
     }
 
+    //화원 id로 회원 엔티티를 조회한다.
     public Member findMember(Long memberId) {
         return em.find(Member.class, memberId);
     }

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminInstructorService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminInstructorService.java
@@ -10,6 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
+/*관리자 강사 계정 생성 비즈니스 로직을 담당하는 서비스.
+*
+* - 강사 계정 생성 전 중복 아이디/이메일을 검증한다.
+* - 비밀번호를 암호화하여 저장한다.
+* - 생성되는 회원의 역할을 Instructor로 고정한다*/
 @Service
 @RequiredArgsConstructor
 public class AdminInstructorService {
@@ -17,6 +22,7 @@ public class AdminInstructorService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
+    //강사 계정을 생성한다.
     @Transactional
     public void createInstructor(AdminInstructorCreateRequest request) {
         validateDuplicate(request);
@@ -39,6 +45,7 @@ public class AdminInstructorService {
         memberRepository.save(member);
     }
 
+    // 강사 생성 요청의 중복 데이터를 검증한다.
     private void validateDuplicate(AdminInstructorCreateRequest request) {
         if (memberRepository.existsByLoginId(request.getLoginId())) {
             throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminMemberService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminMemberService.java
@@ -11,6 +11,12 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/*관리자 회원 관리 비즈니스 로직을 담당하는 서비스.
+*
+* - 검색 조건에 따른 회원 목록을 조회한다.
+* - 특정 회원의 계정 상태를 변경한다.
+* - 특정 회원을 삭제 처리한다.
+* - 관리자 계정은 변경/삭제 대상에서 제외한다.*/
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -18,10 +24,12 @@ public class AdminMemberService {
 
     private final AdminMemberQueryRepository adminMemberQueryRepository;
 
+    //검색 조건에 맞는 회원 목록을 조회한다.
     public List<AdminMemberListResponse> getMembers(AdminMemberSearchCondition condition) {
         return adminMemberQueryRepository.findMembers(condition);
     }
 
+    //특정 회원의 계정 상태를 토글한다.
     public void toggleMemberStatus(Long memberId) {
         Member member = getTarget(memberId);
         validateAdminTarget(member);
@@ -40,6 +48,7 @@ public class AdminMemberService {
         member.setUpdatedAt(LocalDateTime.now());
     }
 
+    //특정 회원을 삭제 처리한다.
     public void deleteMember(Long memberId) {
         Member member = getTarget(memberId);
         validateAdminTarget(member);
@@ -47,6 +56,7 @@ public class AdminMemberService {
         adminMemberQueryRepository.delete(member);
     }
 
+    //처리 대상 회원 엔티티를 조회한다.
     private Member getTarget(Long memberId) {
         Member member = adminMemberQueryRepository.findMember(memberId);
         if (member == null) {
@@ -55,6 +65,7 @@ public class AdminMemberService {
         return member;
     }
 
+    //관리자 계정인지 검증한다.
     private void validateAdminTarget(Member member) {
         if (member.getRole() == Member.MemberRole.ADMIN) {
             throw new IllegalArgumentException("관리자 계정은 처리할 수 없습니다.");

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminRefundService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminRefundService.java
@@ -1,5 +1,6 @@
 package com.wanted.ailienlmsprogram.admin.service;
 
+import com.wanted.ailienlmsprogram.admin.dto.AdminRefundListResponse;
 import com.wanted.ailienlmsprogram.coursecommand.entity.Course;
 import com.wanted.ailienlmsprogram.enrollment.service.EnrollmentService;
 import com.wanted.ailienlmsprogram.payment.entity.Payment;
@@ -13,6 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 
+/*관리자 환불 처리 비즈니스 로직을 담당하는 서비스
+*
+* - 환불 요청 승인 처리
+* - 환불 요청 거절 처리
+* - 승인 시 결제에 포함된 강좌의 수강 취소 처리*/
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -21,10 +27,20 @@ public class AdminRefundService {
     private final RefundRepository refundRepository;
     private final EnrollmentService enrollmentService;
 
+
+    public List<AdminRefundListResponse> getRefunds(Refund.RefundStatus status){
+        List<Refund> refunds = (status == null)
+                ? refundRepository.findAllByOrderByRefundRequestedAtDesc()
+                : refundRepository.findByRefundStatusOrderByRefundRequestedAtDesc(status);
+
+        return refunds.stream().map(AdminRefundListResponse::from)
+                .toList();
+    }
     /**
      * 서버사이드 결제의 REQUESTED 환불을 승인 처리한다.
      * 수강 취소(REFUNDED)까지 한 트랜잭션에서 처리.
      */
+    //환불 요청을 승인 처리한다
     @Transactional
     public void approveRefund(Long refundId) {
         Refund refund = refundRepository.findById(refundId)
@@ -48,6 +64,8 @@ public class AdminRefundService {
     /**
      * 서버사이드 결제의 REQUESTED 환불을 거절 처리한다.
      */
+
+    //환불 요청을 거절 처리한다
     @Transactional
     public void rejectRefund(Long refundId) {
         Refund refund = refundRepository.findById(refundId)

--- a/src/main/resources/templates/admin/refund-list.html
+++ b/src/main/resources/templates/admin/refund-list.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>환불 요청 관리</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #f6f8fb;
+      margin: 0;
+      color: #222;
+    }
+
+    header {
+      background: #3a1f44;
+      color: white;
+      padding: 20px 40px;
+    }
+
+    header h1 {
+      margin: 0 0 10px 0;
+    }
+
+    .top-links a {
+      color: white;
+      text-decoration: none;
+      margin-right: 12px;
+      font-weight: 600;
+    }
+
+    .container {
+      width: 1200px;
+      max-width: calc(100% - 40px);
+      margin: 30px auto;
+    }
+
+    .panel {
+      background: white;
+      border-radius: 14px;
+      padding: 20px 24px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+      margin-bottom: 20px;
+    }
+
+    .message {
+      padding: 14px 16px;
+      border-radius: 10px;
+      margin-bottom: 16px;
+      font-weight: 600;
+    }
+
+    .success {
+      background: #eefaf1;
+      color: #237a3b;
+      border: 1px solid #b8e0c2;
+    }
+
+    .error {
+      background: #fff1f1;
+      color: #b42318;
+      border: 1px solid #f5c2c7;
+    }
+
+    .filter-form {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    select, button {
+      padding: 10px 14px;
+      border-radius: 10px;
+      border: 1px solid #ccc;
+      font-size: 14px;
+    }
+
+    .btn {
+      cursor: pointer;
+      border: none;
+      font-weight: 700;
+    }
+
+    .btn-primary {
+      background: #3a1f44;
+      color: white;
+    }
+
+    .btn-secondary {
+      background: #ece8f0;
+      color: #3a1f44;
+    }
+
+    .btn-approve {
+      background: #1f7a3a;
+      color: white;
+    }
+
+    .btn-reject {
+      background: #b42318;
+      color: white;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: white;
+      border-radius: 14px;
+      overflow: hidden;
+    }
+
+    th, td {
+      padding: 14px 12px;
+      border-bottom: 1px solid #ececec;
+      text-align: left;
+      vertical-align: top;
+      font-size: 14px;
+    }
+
+    th {
+      background: #f4eff7;
+      color: #3a1f44;
+    }
+
+    .status-badge {
+      display: inline-block;
+      padding: 6px 10px;
+      border-radius: 999px;
+      font-size: 12px;
+      font-weight: 700;
+    }
+
+    .requested {
+      background: #fff4e5;
+      color: #9a6700;
+    }
+
+    .approved {
+      background: #eefaf1;
+      color: #237a3b;
+    }
+
+    .rejected {
+      background: #fff1f1;
+      color: #b42318;
+    }
+
+    .action-group {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .empty-box {
+      background: white;
+      border-radius: 14px;
+      padding: 30px;
+      text-align: center;
+      color: #666;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    }
+  </style>
+</head>
+<body>
+<header>
+  <h1>환불 요청 관리</h1>
+  <div class="top-links">
+    <a th:href="@{/admin}">관리자 홈</a>
+    <a th:href="@{/logout}">로그아웃</a>
+  </div>
+</header>
+
+<div class="container">
+
+  <div th:if="${successMsg}" class="message success" th:text="${successMsg}"></div>
+  <div th:if="${errorMsg}" class="message error" th:text="${errorMsg}"></div>
+
+  <div class="panel">
+    <form th:action="@{/admin/refunds}" method="get" class="filter-form">
+      <label for="status"><strong>상태 필터</strong></label>
+      <select id="status" name="status">
+        <option value="">전체</option>
+        <option th:each="refundStatus : ${refundStatuses}"
+                th:value="${refundStatus}"
+                th:text="${refundStatus}"
+                th:selected="${selectedStatus == refundStatus}">
+        </option>
+      </select>
+
+      <button type="submit" class="btn btn-primary">조회</button>
+      <a th:href="@{/admin/refunds}">
+        <button type="button" class="btn btn-secondary">초기화</button>
+      </a>
+    </form>
+  </div>
+
+  <div th:if="${#lists.isEmpty(refunds)}" class="empty-box">
+    조회된 환불 요청이 없습니다.
+  </div>
+
+  <table th:if="${!#lists.isEmpty(refunds)}">
+    <thead>
+    <tr>
+      <th>환불 ID</th>
+      <th>주문번호</th>
+      <th>회원</th>
+      <th>결제금액</th>
+      <th>환불사유</th>
+      <th>상태</th>
+      <th>요청일</th>
+      <th>처리일</th>
+      <th>관리</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="refund : ${refunds}">
+      <td th:text="${refund.refundId}">1</td>
+      <td>
+        <div th:text="${refund.paymentOrderNo}">ORD-20260416-ABCD1234</div>
+        <small th:text="'paymentId: ' + ${refund.paymentId}">paymentId: 1</small>
+      </td>
+      <td>
+        <div th:text="${refund.memberName}">홍길동</div>
+        <small th:text="${refund.memberLoginId}">student01</small>
+      </td>
+      <td th:text="${#numbers.formatInteger(refund.paymentTotalPrice, 3, 'COMMA')} + '원'">10,000원</td>
+      <td th:text="${refund.refundReason}">환불 사유</td>
+      <td>
+                <span th:classappend="${refund.refundStatus.name() == 'REQUESTED'} ? 'status-badge requested' :
+                                       (${refund.refundStatus.name() == 'APPROVED'} ? 'status-badge approved' : 'status-badge rejected')"
+                      th:text="${refund.displayStatus}">
+                    처리 대기
+                </span>
+      </td>
+      <td th:text="${refund.refundRequestedAt != null ? #temporals.format(refund.refundRequestedAt, 'yyyy-MM-dd HH:mm') : '-'}">2026-04-16 10:30</td>
+      <td th:text="${refund.refundProcessedAt != null ? #temporals.format(refund.refundProcessedAt, 'yyyy-MM-dd HH:mm') : '-'}">-</td>
+      <td>
+        <div th:if="${refund.requested}" class="action-group">
+          <form th:action="@{/admin/refunds/{refundId}/approve(refundId=${refund.refundId})}" method="post">
+            <input type="hidden" name="status" th:value="${selectedStatus}">
+            <button type="submit" class="btn btn-approve">승인</button>
+          </form>
+          <form th:action="@{/admin/refunds/{refundId}/reject(refundId=${refund.refundId})}" method="post">
+            <input type="hidden" name="status" th:value="${selectedStatus}">
+            <button type="submit" class="btn btn-reject">거절</button>
+          </form>
+        </div>
+        <div th:unless="${refund.requested}">
+          처리 완료
+        </div>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/refund-list.html
+++ b/src/main/resources/templates/admin/refund-list.html
@@ -215,10 +215,7 @@
     <tbody>
     <tr th:each="refund : ${refunds}">
       <td th:text="${refund.refundId}">1</td>
-      <td>
-        <div th:text="${refund.paymentOrderNo}">ORD-20260416-ABCD1234</div>
-        <small th:text="'paymentId: ' + ${refund.paymentId}">paymentId: 1</small>
-      </td>
+      <td th:text="${refund.paymentOrderNo}">ORD-20260416-ABCD1234</td>
       <td>
         <div th:text="${refund.memberName}">홍길동</div>
         <small th:text="${refund.memberLoginId}">student01</small>


### PR DESCRIPTION
## 관련 이슈
Closes #59 

## 작업 브랜치
- admin-refund-check

## 작업 목적
- 학생이 환불 요청을 보내면 관리자쪽에서 이것을 승인하기 위해 페이지와 로직 구

## 변경 사항
- admin/dto/AdminRefundListResponse dto 추가
- AdminRefundService에 목록 조회 메소드 추가
- GET /admin/refudns 전용 컨트롤러 추가
- 기존 AdminRefundController는 필터 유지 정도만 보완
- 환불 목록 페이지 추가



## 테스트 내용
- [ ] 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] 로컬 실행 확인

