### PR TITLE
ui

### DIFF
--- a/src/main/resources/templates/student/cart.html
+++ b/src/main/resources/templates/student/cart.html
@@ -8,7 +8,6 @@
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;500;600;700&family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
-    <!-- 토스페이먼츠 JS SDK v2 -->
     <script src="https://js.tosspayments.com/v2/standard"></script>
 
     <script id="tailwind-config">
@@ -21,7 +20,6 @@
                         "ow-orange-hover": "#FFB84D",
                         "ow-blue": "#00B4FF",
                         "ow-dark": "#1D2127",
-                        "ow-panel": "rgba(29, 33, 39, 0.85)",
                     },
                     fontFamily: {
                         "ow": ["Oswald", "sans-serif"],
@@ -37,7 +35,7 @@
         .bg-sci-fi {
             position: fixed; inset: 0; z-index: -3;
             background-image: radial-gradient(circle at 30% 50%, rgba(0,0,0,.2) 0%, rgba(0,0,0,.9) 100%),
-                              url("https://images.unsplash.com/photo-1541701494587-cb58502866ab?q=80&w=2070&auto=format&fit=crop");
+            url("https://images.unsplash.com/photo-1541701494587-cb58502866ab?q=80&w=2070&auto=format&fit=crop");
             background-size: cover; background-position: center;
         }
         .bg-overlay {
@@ -45,42 +43,139 @@
             background: linear-gradient(90deg, rgba(11,14,20,1) 0%, rgba(11,14,20,.8) 30%, transparent 100%);
         }
         .ow-font-italic { font-family: 'Oswald', sans-serif; font-style: italic; text-transform: uppercase; }
-        .ow-card {
-            background: rgba(29,33,39,.6); backdrop-filter: blur(15px);
-            border: 1px solid rgba(255,255,255,.1); border-left: 6px solid rgba(255,255,255,.2);
-            clip-path: polygon(0 0,100% 0,100% calc(100% - 16px),calc(100% - 16px) 100%,0 100%);
-            transition: all .2s ease;
-        }
-        .ow-card.selected { border-left-color: #FF9C00; background: rgba(40,45,55,.9); }
-        .ow-card:hover { background: rgba(40,45,55,.95); }
         .material-symbols-outlined { font-variation-settings: 'FILL' 1,'wght' 400,'GRAD' 0,'opsz' 24; vertical-align: middle; }
 
-        /* 체크박스 커스텀 스타일 */
+        /* ── 공통 카드 ── */
+        .ow-card {
+            background: rgba(29,33,39,.75); backdrop-filter: blur(16px);
+            border: 1px solid rgba(255,255,255,.08); border-radius: 4px;
+        }
+
+        /* ── 2단 레이아웃 ── */
+        .cart-layout {
+            display: grid;
+            grid-template-columns: 1fr 300px;
+            gap: 20px;
+            align-items: start;
+        }
+
+        /* ── 강좌 목록 ── */
+        .select-all-bar {
+            display: flex; align-items: center; gap: 10px;
+            padding: 13px 20px;
+            border-bottom: 1px solid rgba(255,255,255,.06);
+            background: rgba(0,0,0,.15);
+        }
+        .course-item {
+            display: flex; align-items: center; gap: 14px;
+            padding: 16px 20px;
+            border-bottom: 1px solid rgba(255,255,255,.05);
+            border-left: 3px solid transparent;
+            transition: background .15s, border-left-color .15s;
+        }
+        .course-item:last-child { border-bottom: none; }
+        .course-item:hover { background: rgba(255,255,255,.02); }
+        .course-item.selected { background: rgba(255,156,0,.04); border-left-color: #FF9C00; }
+
+        .course-thumb {
+            width: 76px; height: 52px; border-radius: 3px; flex-shrink: 0;
+            background: rgba(255,255,255,.05);
+            border: 1px solid rgba(255,255,255,.07);
+            display: flex; align-items: center; justify-content: center;
+        }
+        .course-title {
+            font-size: 14px; font-weight: 600; color: #e5e7eb;
+            margin-bottom: 4px; line-height: 1.4;
+        }
+        .course-instructor { font-size: 12px; color: #6b7280; }
+        .course-price {
+            font-family: 'Oswald', sans-serif; font-style: italic;
+            font-size: 17px; color: #00B4FF; font-weight: 700;
+            white-space: nowrap; flex-shrink: 0;
+        }
+        .delete-btn {
+            flex-shrink: 0; background: none; border: none;
+            color: rgba(255,255,255,.18); cursor: pointer;
+            transition: color .15s; display: flex; align-items: center; padding: 4px;
+        }
+        .delete-btn:hover { color: #ef4444; }
+
+        /* ── 체크박스 ── */
         .cart-checkbox {
             appearance: none; -webkit-appearance: none;
-            width: 20px; height: 20px; flex-shrink: 0;
-            border: 2px solid rgba(255,255,255,.3); border-radius: 3px;
-            cursor: pointer; transition: all .15s ease;
-            position: relative;
+            width: 18px; height: 18px; flex-shrink: 0;
+            border: 2px solid rgba(255,255,255,.2); border-radius: 3px;
+            cursor: pointer; transition: all .15s; position: relative;
         }
-        .cart-checkbox:checked {
-            background-color: #FF9C00; border-color: #FF9C00;
-        }
+        .cart-checkbox:checked { background: #FF9C00; border-color: #FF9C00; }
         .cart-checkbox:checked::after {
             content: ''; position: absolute;
-            left: 5px; top: 2px; width: 6px; height: 10px;
+            left: 4px; top: 1px; width: 5px; height: 9px;
             border: 2px solid #000; border-top: none; border-left: none;
             transform: rotate(45deg);
         }
         .cart-checkbox:hover { border-color: #FF9C00; }
+
+        /* ── 결제 패널 ── */
+        .payment-panel { position: sticky; top: 100px; }
+        .panel-section {
+            padding: 16px 18px;
+            border-bottom: 1px solid rgba(255,255,255,.06);
+        }
+        .panel-section:last-child { border-bottom: none; }
+        .panel-section-title {
+            font-family: 'Oswald', sans-serif; font-style: italic;
+            font-size: 11px; color: #4b5563; letter-spacing: 1.5px;
+            text-transform: uppercase; margin-bottom: 12px;
+        }
+        .discount-row {
+            display: flex; justify-content: space-between; align-items: center;
+            font-size: 13px; color: #6b7280; margin-bottom: 9px;
+        }
+        .discount-row:last-child { margin-bottom: 0; }
+        .discount-tag {
+            font-size: 10px; padding: 1px 5px; border-radius: 2px;
+            background: rgba(255,255,255,.06); color: #4b5563; margin-left: 5px;
+        }
+        .summary-row {
+            display: flex; justify-content: space-between;
+            font-size: 13px; color: #6b7280; margin-bottom: 7px;
+        }
+        .summary-row:last-child { margin-bottom: 0; }
+        .summary-val { color: #9ca3af; font-weight: 500; }
+        .total-row {
+            display: flex; justify-content: space-between; align-items: center;
+            padding-top: 12px; margin-top: 2px;
+            border-top: 1px solid rgba(255,255,255,.07);
+        }
+        .total-label { font-family: 'Oswald', sans-serif; font-style: italic; font-size: 12px; color: #6b7280; letter-spacing: 1px; text-transform: uppercase; }
+        .total-amount { font-family: 'Oswald', sans-serif; font-style: italic; font-size: 24px; font-weight: 700; color: #FF9C00; }
+
+        .checkout-btn {
+            display: block; width: 100%; padding: 14px;
+            background: #FF9C00; color: #000;
+            font-family: 'Oswald', sans-serif; font-style: italic;
+            font-size: 14px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase;
+            border: none; cursor: pointer; transition: background .15s;
+            clip-path: polygon(0 0,100% 0,100% calc(100% - 8px),calc(100% - 8px) 100%,0 100%);
+        }
+        .checkout-btn:hover:not(:disabled) { background: #FFB84D; }
+        .checkout-btn:disabled {
+            background: rgba(255,255,255,.08); color: rgba(255,255,255,.2);
+            cursor: not-allowed; clip-path: none;
+        }
+
+        /* 알림 */
+        .alert-success { background: rgba(34,197,94,.08); border: 1px solid rgba(34,197,94,.25); color: #86efac; padding: 13px 16px; border-radius: 4px; font-size: 13px; margin-bottom: 16px; }
+        .alert-error   { background: rgba(239,68,68,.08); border: 1px solid rgba(239,68,68,.25); color: #fca5a5; padding: 13px 16px; border-radius: 4px; font-size: 13px; margin-bottom: 16px; }
     </style>
 </head>
 
 <body class="min-h-screen relative">
-
 <div class="bg-sci-fi"></div>
 <div class="bg-overlay"></div>
 
+<!-- ── 헤더 ── -->
 <header class="fixed top-0 left-0 right-0 z-50 flex justify-between items-start p-6 pointer-events-none">
     <div class="pointer-events-auto">
         <h1 class="ow-font-italic text-5xl font-bold text-white tracking-wider drop-shadow-[0_2px_10px_rgba(0,0,0,0.8)]">
@@ -88,7 +183,6 @@
         </h1>
         <p class="font-body text-xs text-gray-400 tracking-widest mt-1">ALIEN UNIVERSE LEARNING PLATFORM</p>
     </div>
-
     <div class="pointer-events-auto flex items-stretch bg-white text-black rounded-sm shadow-[0_5px_20px_rgba(0,0,0,0.6)] overflow-hidden" th:if="${loginMember != null}">
         <div class="bg-gray-200 px-4 py-2 flex items-center justify-center border-r border-gray-300">
             <span class="material-symbols-outlined text-gray-700 text-4xl">account_circle</span>
@@ -103,237 +197,180 @@
     </div>
 </header>
 
-<main class="min-h-screen max-w-5xl mx-auto px-6 pt-36 pb-40">
-
+<!-- ── 메인 ── -->
+<main class="min-h-screen max-w-6xl mx-auto px-6 pt-36 pb-16">
     <div class="mb-8 flex items-center justify-between">
         <h2 class="ow-font-italic text-4xl font-bold text-white tracking-wide flex items-center gap-3">
             <span class="text-ow-orange">></span>
             CART <span class="text-gray-600 text-xl font-normal">// 수강 바구니</span>
         </h2>
-        <a th:href="@{/student}" class="font-body text-sm text-gray-400 hover:text-ow-orange transition-colors">
-            &larr; 학생 홈
-        </a>
+        <a th:href="@{/student}" class="font-body text-sm text-gray-400 hover:text-ow-orange transition-colors">← 학생 홈</a>
     </div>
 
-    <!-- 알림 메시지 -->
-    <div th:if="${successMsg}" class="mb-6 p-4 bg-green-900/40 border border-green-500/40 text-green-300 font-body text-sm rounded"
-         th:text="${successMsg}"></div>
-    <div th:if="${errorMsg}" class="mb-6 p-4 bg-red-900/40 border border-red-500/40 text-red-300 font-body text-sm rounded"
-         th:text="${errorMsg}"></div>
+    <div th:if="${successMsg}" class="alert-success" th:text="${successMsg}"></div>
+    <div th:if="${errorMsg}"   class="alert-error"   th:text="${errorMsg}"></div>
 
     <!-- 빈 바구니 -->
-    <div th:if="${#lists.isEmpty(cartItems)}" class="ow-card p-16 text-center">
+    <div th:if="${#lists.isEmpty(cartItems)}" class="ow-card" style="padding:80px 24px; text-align:center;">
         <span class="material-symbols-outlined text-6xl text-gray-600 mb-4 block">shopping_cart</span>
         <p class="ow-font-italic text-2xl text-gray-500">CART IS EMPTY</p>
         <p class="font-body text-sm text-gray-600 mt-2">대륙 탐색에서 강좌를 담아보십시오.</p>
     </div>
 
-    <!-- 강좌 목록 -->
-    <div th:if="${!#lists.isEmpty(cartItems)}">
+    <!-- 2단 레이아웃 -->
+    <div th:if="${!#lists.isEmpty(cartItems)}" class="cart-layout">
 
-        <!-- 전체 선택 헤더 -->
-        <div class="flex items-center gap-4 px-2 mb-3">
-            <input type="checkbox" id="select-all" class="cart-checkbox"/>
-            <label for="select-all" class="font-body text-sm text-gray-400 cursor-pointer select-none">
-                전체 선택
-            </label>
+        <!-- 좌측: 강좌 목록 -->
+        <div>
+            <div class="ow-card" style="overflow:hidden;">
+                <div class="select-all-bar">
+                    <input type="checkbox" id="select-all" class="cart-checkbox"/>
+                    <label for="select-all" class="font-body text-sm text-gray-400 cursor-pointer select-none">전체 선택</label>
+                    <span class="font-body text-xs text-gray-600 ml-1" id="select-count-text"></span>
+                </div>
+                <div id="cart-list">
+                    <div th:each="item : ${cartItems}"
+                         class="course-item cart-item-row"
+                         th:data-cart-id="${item.cartId}"
+                         th:data-price="${item.price}">
+
+                        <input type="checkbox" class="cart-checkbox item-checkbox"
+                               th:data-cart-id="${item.cartId}" th:data-price="${item.price}"/>
+
+                        <div class="course-thumb">
+                            <span class="material-symbols-outlined text-gray-600" style="font-size:26px; font-variation-settings:'FILL' 0,'wght' 200,'GRAD' 0,'opsz' 24;">school</span>
+                        </div>
+
+                        <div style="flex:1; min-width:0;">
+                            <p class="course-title" th:text="${item.courseTitle}">강좌명</p>
+                            <p class="course-instructor">
+                                <span class="material-symbols-outlined" style="font-size:11px;">person</span>
+                                <span th:text="${item.instructorName}">강사명</span>
+                            </p>
+                        </div>
+
+                        <p class="course-price" th:text="${#numbers.formatInteger(item.price, 3, 'COMMA')} + '원'">0원</p>
+
+                        <form th:action="@{/student/cart/{id}/delete(id=${item.cartId})}" method="post">
+                            <button type="submit" class="delete-btn" title="삭제">
+                                <span class="material-symbols-outlined" style="font-size:17px; font-variation-settings:'FILL' 0,'wght' 300,'GRAD' 0,'opsz' 24;">close</span>
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+            <div style="margin-top:10px;">
+                <a th:href="@{/student}" class="font-body text-xs text-gray-600 hover:text-ow-orange transition-colors">← 강좌 더 보기</a>
+            </div>
         </div>
 
-        <!-- 강좌 카드 목록 -->
-        <div class="flex flex-col gap-3 mb-6" id="cart-list">
-            <div th:each="item : ${cartItems}"
-                 class="ow-card p-5 flex items-center gap-5 cart-item-row"
-                 th:data-cart-id="${item.cartId}"
-                 th:data-price="${item.price}">
+        <!-- 우측: 결제 패널 -->
+        <div class="payment-panel">
+            <div class="ow-card" style="overflow:hidden;">
 
-                <!-- 체크박스 -->
-                <input type="checkbox"
-                       class="cart-checkbox item-checkbox"
-                       th:data-cart-id="${item.cartId}"
-                       th:data-price="${item.price}"/>
+                <div class="panel-section">
+                    <div class="summary-row">
+                        <span>강좌 금액</span>
+                        <span class="summary-val" id="panel-subtotal">0원</span>
+                    </div>
+                    <div class="total-row">
+                        <span class="total-label">결제 금액</span>
+                        <span class="total-amount" id="panel-total">0원</span>
+                    </div>
+                </div>
 
-                <!-- 강좌 정보 -->
-                <div class="flex-1 min-w-0">
-                    <p class="ow-font-italic text-xl text-white truncate" th:text="${item.courseTitle}">강좌명</p>
-                    <p class="font-body text-sm text-gray-400 mt-1">
-                        <span class="material-symbols-outlined text-xs mr-1">person</span>
-                        <span th:text="${item.instructorName}">강사명</span>
+                <div class="panel-section">
+                    <div class="font-body text-xs text-gray-600 mb-3">
+                        선택된 강좌: <span id="selected-count" class="text-gray-400 font-bold">0개</span>
+                    </div>
+                    <button id="toss-checkout-btn" class="checkout-btn" disabled>결제하기 &gt;</button>
+                    <p class="font-body text-xs text-gray-700 text-center mt-3 leading-relaxed">
+                        주문 내용을 확인하였으며 결제에 동의합니다.
                     </p>
                 </div>
 
-                <!-- 가격 -->
-                <div class="text-right flex-shrink-0 w-28">
-                    <p class="ow-font-italic text-2xl text-ow-blue font-bold"
-                       th:text="${#numbers.formatInteger(item.price, 3, 'COMMA')} + '원'">0원</p>
-                </div>
-
-                <!-- 삭제 버튼 -->
-                <form th:action="@{/student/cart/{id}/delete(id=${item.cartId})}" method="post" class="flex-shrink-0">
-                    <button type="submit"
-                            class="ow-font-italic text-xs px-4 py-2 border border-gray-600 hover:border-red-500 hover:text-red-400 text-gray-500 transition-colors cursor-pointer whitespace-nowrap">
-                        삭제
-                    </button>
-                </form>
-
             </div>
         </div>
-
-        <!-- 하단 고정 결제 패널 -->
-        <div class="fixed bottom-0 left-0 right-0 z-40 pointer-events-none">
-            <div class="max-w-5xl mx-auto px-6 pb-6 pointer-events-auto">
-                <div class="ow-card p-6 flex items-center justify-between gap-6" style="border-left-color: #FF9C00;">
-
-                    <div class="flex-1">
-                        <p class="font-body text-xs text-gray-500 mb-1">선택된 강좌</p>
-                        <p class="ow-font-italic text-sm text-gray-300">
-                            <span id="selected-count">0개</span>
-                        </p>
-                    </div>
-
-                    <div class="text-center">
-                        <p class="font-body text-xs text-gray-500 mb-1">결제 금액</p>
-                        <p class="ow-font-italic text-3xl font-bold text-ow-orange" id="selected-total">0원</p>
-                    </div>
-
-                    <div class="flex items-center gap-3">
-                        <button id="toss-checkout-btn"
-                                disabled
-                                class="ow-font-italic text-base px-10 py-4 bg-ow-orange text-white font-bold tracking-widest transition-all cursor-not-allowed opacity-40"
-                                style="clip-path: polygon(0 0,100% 0,100% calc(100% - 10px),calc(100% - 10px) 100%,0 100%);">
-                            선택 결제 &gt;
-                        </button>
-                    </div>
-
-                </div>
-            </div>
-        </div>
-
     </div>
-
 </main>
 
-<!-- Thymeleaf → JavaScript 변수 주입 -->
 <script th:inline="javascript">
-    const TOSS_CLIENT_KEY  = /*[[${tossClientKey}]]*/ '';
-    const CUSTOMER_KEY     = /*[[|member_${loginMember.memberId}|]]*/ '';
-    const CUSTOMER_NAME    = /*[[${loginMember.name}]]*/ '';
-    const CUSTOMER_EMAIL   = /*[[${loginMember.email}]]*/ '';
-
+    const TOSS_CLIENT_KEY = /*[[${tossClientKey}]]*/ '';
+    const CUSTOMER_KEY    = /*[[|member_${loginMember.memberId}|]]*/ '';
+    const CUSTOMER_NAME   = /*[[${loginMember.name}]]*/ '';
+    const CUSTOMER_EMAIL  = /*[[${loginMember.email}]]*/ '';
     function getCsrfToken() {
-        const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/);
-        return match ? decodeURIComponent(match[1]) : '';
+        const m = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/);
+        return m ? decodeURIComponent(m[1]) : '';
     }
 </script>
 
 <script>
-    // ── 선택 상태 관리 ────────────────────────────────────────────────────────
-
-    function getSelectedItems() {
-        return Array.from(document.querySelectorAll('.item-checkbox:checked'));
-    }
+    const allCheckboxes = document.querySelectorAll('.item-checkbox');
+    function getSelected() { return Array.from(document.querySelectorAll('.item-checkbox:checked')); }
+    function fmt(n) { return n.toLocaleString('ko-KR') + '원'; }
 
     function updateSummary() {
-        const checked = getSelectedItems();
-        const total   = checked.reduce((sum, cb) => sum + parseInt(cb.dataset.price, 10), 0);
+        const checked = getSelected();
+        const total   = checked.reduce((s, cb) => s + parseInt(cb.dataset.price, 10), 0);
         const count   = checked.length;
 
-        document.getElementById('selected-count').textContent = count + '개 강좌';
-        document.getElementById('selected-total').textContent = total.toLocaleString('ko-KR') + '원';
+        document.getElementById('selected-count').textContent  = count + '개';
+        document.getElementById('panel-subtotal').textContent  = fmt(total);
+        document.getElementById('panel-total').textContent     = fmt(total);
+
+        const ct = document.getElementById('select-count-text');
+        if (ct) ct.textContent = count + ' / ' + allCheckboxes.length;
+
+        document.querySelectorAll('.cart-item-row').forEach(row => {
+            row.classList.toggle('selected', row.querySelector('.item-checkbox').checked);
+        });
+
+        const all = document.querySelectorAll('.item-checkbox');
+        document.getElementById('select-all').checked = count === all.length && all.length > 0;
 
         const btn = document.getElementById('toss-checkout-btn');
-        if (count > 0) {
-            btn.disabled = false;
-            btn.classList.remove('opacity-40', 'cursor-not-allowed');
-            btn.classList.add('hover:bg-ow-orange-hover', 'cursor-pointer');
-        } else {
-            btn.disabled = true;
-            btn.classList.add('opacity-40', 'cursor-not-allowed');
-            btn.classList.remove('hover:bg-ow-orange-hover', 'cursor-pointer');
-        }
-
-        // 카드 테두리 강조
-        document.querySelectorAll('.cart-item-row').forEach(row => {
-            const cb = row.querySelector('.item-checkbox');
-            row.classList.toggle('selected', cb.checked);
-        });
-
-        // 전체 선택 체크박스 상태 동기화
-        const all  = document.querySelectorAll('.item-checkbox');
-        const allChecked = count === all.length && all.length > 0;
-        document.getElementById('select-all').checked = allChecked;
+        btn.disabled = count === 0;
     }
 
-    // 전체 선택/해제
-    document.getElementById('select-all').addEventListener('change', function() {
-        document.querySelectorAll('.item-checkbox').forEach(cb => {
-            cb.checked = this.checked;
-        });
-        updateSummary();
+    document.getElementById('select-all').addEventListener('change', function () {
+        allCheckboxes.forEach(cb => cb.checked = this.checked); updateSummary();
     });
+    allCheckboxes.forEach(cb => cb.addEventListener('change', updateSummary));
+    updateSummary();
 
-    // 개별 체크박스 변경
-    document.querySelectorAll('.item-checkbox').forEach(cb => {
-        cb.addEventListener('change', updateSummary);
-    });
-
-    // ── 토스페이먼츠 결제 ─────────────────────────────────────────────────────
-
-    document.getElementById('toss-checkout-btn').addEventListener('click', async function() {
-        const cartIds = getSelectedItems().map(cb => parseInt(cb.dataset.cartId, 10));
-
-        if (cartIds.length === 0) return;
-
-        // 버튼 로딩 상태
-        this.textContent = '결제 준비 중...';
-        this.disabled = true;
-
+    document.getElementById('toss-checkout-btn').addEventListener('click', async function () {
+        const cartIds = getSelected().map(cb => parseInt(cb.dataset.cartId, 10));
+        if (!cartIds.length) return;
+        this.textContent = '결제 준비 중...'; this.disabled = true;
         try {
-            // STEP 1: 주문 정보 생성 (orderId, amount, orderName)
             const prepRes = await fetch('/student/cart/toss/prepare', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-XSRF-TOKEN': getCsrfToken()
-                },
+                headers: { 'Content-Type': 'application/json', 'X-XSRF-TOKEN': getCsrfToken() },
                 body: JSON.stringify({ cartIds })
             });
-
             if (!prepRes.ok) {
                 const err = await prepRes.json().catch(() => ({}));
                 alert(err.error ?? '결제 준비 중 오류가 발생했습니다.');
-                this.textContent = '선택 결제 >';
-                this.disabled = false;
-                return;
+                this.textContent = '결제하기 >'; this.disabled = false; return;
             }
-
             const { orderId, amount, orderName } = await prepRes.json();
-
-            // STEP 2: 토스페이먼츠 결제창 열기
             const tossPayments = TossPayments(TOSS_CLIENT_KEY);
             const payment = tossPayments.payment({ customerKey: TossPayments.ANONYMOUS });
-
             await payment.requestPayment({
                 method: 'CARD',
                 amount: { currency: 'KRW', value: amount },
-                orderId: orderId,
-                orderName: orderName,
+                orderId, orderName,
                 successUrl: window.location.origin + '/student/cart/payment/success',
                 failUrl:    window.location.origin + '/student/cart/payment/fail',
-                customerEmail: CUSTOMER_EMAIL,
-                customerName:  CUSTOMER_NAME,
+                customerEmail: CUSTOMER_EMAIL, customerName: CUSTOMER_NAME,
             });
-
         } catch (e) {
-            // SDK 에러 (사용자 취소 포함)
-            console.error('[Toss Error]', JSON.stringify(e), e);
-            if (e.code !== 'USER_CANCEL') {
-                alert('결제 중 오류가 발생했습니다: ' + (e.code ?? '') + ' ' + (e.message ?? e));
-            }
-            this.textContent = '선택 결제 >';
-            this.disabled = getSelectedItems().length === 0;
+            console.error('[Toss Error]', e);
+            if (e.code !== 'USER_CANCEL') alert('결제 오류: ' + (e.code ?? '') + ' ' + (e.message ?? e));
+            this.textContent = '결제하기 >'; this.disabled = getSelected().length === 0;
         }
     });
 </script>
-
 </body>
 </html>

--- a/src/main/resources/templates/student/payment-detail.html
+++ b/src/main/resources/templates/student/payment-detail.html
@@ -12,20 +12,7 @@
     <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
-            theme: {
-                extend: {
-                    colors: {
-                        "ow-orange": "#FF9C00",
-                        "ow-orange-hover": "#FFB84D",
-                        "ow-blue": "#00B4FF",
-                        "ow-dark": "#1D2127",
-                    },
-                    fontFamily: {
-                        "ow": ["Oswald", "sans-serif"],
-                        "body": ["Noto Sans KR", "sans-serif"],
-                    }
-                },
-            },
+            theme: { extend: { colors: { "ow-orange": "#FF9C00", "ow-orange-hover": "#FFB84D", "ow-blue": "#00B4FF" }, fontFamily: { "ow": ["Oswald", "sans-serif"], "body": ["Noto Sans KR", "sans-serif"] } } }
         }
     </script>
 
@@ -34,31 +21,91 @@
         .bg-sci-fi {
             position: fixed; inset: 0; z-index: -3;
             background-image: radial-gradient(circle at 30% 50%, rgba(0,0,0,.2) 0%, rgba(0,0,0,.9) 100%),
-                              url("https://images.unsplash.com/photo-1541701494587-cb58502866ab?q=80&w=2070&auto=format&fit=crop");
+            url("https://images.unsplash.com/photo-1541701494587-cb58502866ab?q=80&w=2070&auto=format&fit=crop");
             background-size: cover; background-position: center;
         }
-        .bg-overlay {
-            position: fixed; inset: 0; z-index: -2;
-            background: linear-gradient(90deg, rgba(11,14,20,1) 0%, rgba(11,14,20,.8) 30%, transparent 100%);
-        }
+        .bg-overlay { position: fixed; inset: 0; z-index: -2; background: linear-gradient(90deg, rgba(11,14,20,1) 0%, rgba(11,14,20,.8) 30%, transparent 100%); }
         .ow-font-italic { font-family: 'Oswald', sans-serif; font-style: italic; text-transform: uppercase; }
-        .ow-card {
-            background: rgba(29,33,39,.6); backdrop-filter: blur(15px);
-            border: 1px solid rgba(255,255,255,.1); border-left: 6px solid rgba(255,255,255,.2);
-            clip-path: polygon(0 0,100% 0,100% calc(100% - 16px),calc(100% - 16px) 100%,0 100%);
-        }
-        .ow-card-orange { border-left-color: #FF9C00; }
-        .ow-card-blue   { border-left-color: #00B4FF; }
-        .ow-card-red    { border-left-color: #ef4444; }
         .material-symbols-outlined { font-variation-settings: 'FILL' 1,'wght' 400,'GRAD' 0,'opsz' 24; vertical-align: middle; }
+
+        /* ── 정보 카드 공통 ── */
+        .info-card {
+            background: rgba(29,33,39,.75); backdrop-filter: blur(16px);
+            border: 1px solid rgba(255,255,255,.08); border-radius: 4px;
+            border-left: 3px solid rgba(255,255,255,.1);
+            padding: 22px 24px;
+            margin-bottom: 14px;
+        }
+        .info-card.orange { border-left-color: #FF9C00; }
+        .info-card.blue   { border-left-color: #00B4FF; }
+        .info-card.red    { border-left-color: #ef4444; }
+
+        .card-title {
+            font-family: 'Oswald', sans-serif; font-style: italic;
+            font-size: 13px; color: #6b7280; letter-spacing: 1.5px;
+            text-transform: uppercase; margin-bottom: 18px;
+            display: flex; align-items: center; gap: 8px;
+        }
+        .card-title span.material-symbols-outlined { font-size: 16px; }
+
+        /* 정보 그리드 */
+        .info-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+        .info-label { font-size: 11px; color: #4b5563; margin-bottom: 4px; letter-spacing: .5px; text-transform: uppercase; }
+        .info-value { font-size: 14px; color: #d1d5db; font-weight: 500; }
+        .info-value.big { font-family: 'Oswald', sans-serif; font-style: italic; font-size: 26px; font-weight: 700; color: #00B4FF; }
+
+        /* 강좌 행 */
+        .course-row {
+            display: flex; align-items: center; justify-content: space-between;
+            padding: 12px 0; border-bottom: 1px solid rgba(255,255,255,.05);
+        }
+        .course-row:last-child { border-bottom: none; padding-bottom: 0; }
+        .course-row:first-child { padding-top: 0; }
+        .course-row-title { font-size: 14px; color: #d1d5db; font-weight: 500; margin-bottom: 3px; }
+        .course-row-instructor { font-size: 12px; color: #4b5563; }
+        .course-row-price { font-family: 'Oswald', sans-serif; font-style: italic; font-size: 15px; color: #00B4FF; white-space: nowrap; }
+
+        /* 환불 폼 */
+        .refund-textarea {
+            width: 100%; padding: 12px; border-radius: 3px;
+            border: 1px solid rgba(255,255,255,.1);
+            background: rgba(0,0,0,.3); color: #d1d5db;
+            font-family: 'Noto Sans KR', sans-serif; font-size: 13px;
+            resize: none; outline: none; transition: border-color .15s;
+        }
+        .refund-textarea:focus { border-color: rgba(239,68,68,.5); }
+        .refund-textarea::placeholder { color: #374151; }
+
+        .refund-submit {
+            font-family: 'Oswald', sans-serif; font-style: italic;
+            padding: 9px 24px; font-size: 12px; font-weight: 700; letter-spacing: 1px;
+            border: 1px solid rgba(239,68,68,.5); color: #f87171;
+            background: rgba(239,68,68,.06); cursor: pointer;
+            transition: all .15s; text-transform: uppercase;
+        }
+        .refund-submit:hover { background: rgba(239,68,68,.15); border-color: #ef4444; }
+
+        /* 상태 뱃지 */
+        .status-badge {
+            font-family: 'Oswald', sans-serif; font-style: italic;
+            display: inline-block; padding: 4px 10px; font-size: 11px; font-weight: 600;
+            letter-spacing: .5px;
+        }
+        .badge-requested { background: rgba(234,179,8,.1); border: 1px solid rgba(234,179,8,.3); color: #fbbf24; }
+        .badge-approved  { background: rgba(34,197,94,.1);  border: 1px solid rgba(34,197,94,.3);  color: #4ade80; }
+        .badge-rejected  { background: rgba(255,255,255,.05); border: 1px solid rgba(255,255,255,.1); color: #6b7280; }
+
+        /* 알림 */
+        .alert-success { background: rgba(34,197,94,.08); border: 1px solid rgba(34,197,94,.25); color: #86efac; padding: 13px 16px; border-radius: 4px; font-size: 13px; margin-bottom: 16px; }
+        .alert-error   { background: rgba(239,68,68,.08); border: 1px solid rgba(239,68,68,.25); color: #fca5a5; padding: 13px 16px; border-radius: 4px; font-size: 13px; margin-bottom: 16px; }
     </style>
 </head>
 
 <body class="min-h-screen relative">
-
 <div class="bg-sci-fi"></div>
 <div class="bg-overlay"></div>
 
+<!-- ── 헤더 ── -->
 <header class="fixed top-0 left-0 right-0 z-50 flex justify-between items-start p-6 pointer-events-none">
     <div class="pointer-events-auto">
         <h1 class="ow-font-italic text-5xl font-bold text-white tracking-wider drop-shadow-[0_2px_10px_rgba(0,0,0,0.8)]">
@@ -66,7 +113,6 @@
         </h1>
         <p class="font-body text-xs text-gray-400 tracking-widest mt-1">ALIEN UNIVERSE LEARNING PLATFORM</p>
     </div>
-
     <div class="pointer-events-auto flex items-stretch bg-white text-black rounded-sm shadow-[0_5px_20px_rgba(0,0,0,0.6)] overflow-hidden" th:if="${loginMember != null}">
         <div class="bg-gray-200 px-4 py-2 flex items-center justify-center border-r border-gray-300">
             <span class="material-symbols-outlined text-gray-700 text-4xl">account_circle</span>
@@ -81,119 +127,100 @@
     </div>
 </header>
 
+<!-- ── 메인 ── -->
 <main class="min-h-screen max-w-4xl mx-auto px-6 pt-36 pb-16">
-
     <div class="mb-8 flex items-center justify-between">
         <h2 class="ow-font-italic text-4xl font-bold text-white tracking-wide flex items-center gap-3">
             <span class="text-ow-orange">></span>
             RECEIPT <span class="text-gray-600 text-xl font-normal">// 결제 상세</span>
         </h2>
-        <a th:href="@{/student/payments}" class="font-body text-sm text-gray-400 hover:text-ow-orange transition-colors">
-            &larr; 결제 내역
-        </a>
+        <a th:href="@{/student/payments}" class="font-body text-sm text-gray-400 hover:text-ow-orange transition-colors">← 결제 내역</a>
     </div>
 
-    <!-- 알림 -->
-    <div th:if="${successMsg}" class="mb-6 p-4 bg-green-900/40 border border-green-500/40 text-green-300 font-body text-sm rounded" th:text="${successMsg}"></div>
-    <div th:if="${errorMsg}" class="mb-6 p-4 bg-red-900/40 border border-red-500/40 text-red-300 font-body text-sm rounded" th:text="${errorMsg}"></div>
+    <div th:if="${successMsg}" class="alert-success" th:text="${successMsg}"></div>
+    <div th:if="${errorMsg}"   class="alert-error"   th:text="${errorMsg}"></div>
 
     <!-- 결제 정보 -->
-    <div class="ow-card ow-card-orange p-6 mb-6">
-        <h3 class="ow-font-italic text-xl text-ow-orange mb-4 flex items-center gap-2">
-            <span class="material-symbols-outlined">receipt</span> TRANSACTION INFO
-        </h3>
-        <div class="grid grid-cols-2 gap-4 font-body text-sm">
+    <div class="info-card orange">
+        <p class="card-title"><span class="material-symbols-outlined" style="color:#FF9C00;">receipt</span> Transaction Info</p>
+        <div class="info-grid">
             <div>
-                <p class="text-gray-500 mb-1">주문번호</p>
-                <p class="text-white font-bold" th:text="${detail.payment.paymentOrderNo}">-</p>
+                <p class="info-label">주문번호</p>
+                <p class="info-value" style="font-size:13px; font-family:monospace;" th:text="${detail.payment.paymentOrderNo}">-</p>
             </div>
             <div>
-                <p class="text-gray-500 mb-1">결제 완료 일시</p>
-                <p class="text-white" th:text="${#temporals.format(detail.payment.paymentCompletedAt, 'yyyy-MM-dd HH:mm:ss')}">-</p>
+                <p class="info-label">결제 완료 일시</p>
+                <p class="info-value" th:text="${#temporals.format(detail.payment.paymentCompletedAt, 'yyyy-MM-dd HH:mm:ss')}">-</p>
             </div>
-            <div class="col-span-2">
-                <p class="text-gray-500 mb-1">총 결제 금액</p>
-                <p class="ow-font-italic text-2xl text-ow-blue font-bold"
-                   th:text="${#numbers.formatInteger(detail.payment.paymentTotalPrice, 3, 'COMMA')} + '원'">-</p>
+            <div style="grid-column: 1 / -1; margin-top:4px;">
+                <p class="info-label">총 결제 금액</p>
+                <p class="info-value big" th:text="${#numbers.formatInteger(detail.payment.paymentTotalPrice, 3, 'COMMA')} + '원'">-</p>
             </div>
         </div>
     </div>
 
     <!-- 구매 강좌 목록 -->
-    <div class="ow-card ow-card-blue p-6 mb-6">
-        <h3 class="ow-font-italic text-xl text-ow-blue mb-4 flex items-center gap-2">
-            <span class="material-symbols-outlined">school</span> ACQUIRED PROTOCOLS
-        </h3>
-
-        <div class="flex flex-col gap-3">
-            <div th:each="item : ${detail.items}"
-                 class="flex items-center justify-between py-3 border-b border-white/5 last:border-0">
-                <div class="min-w-0">
-                    <p class="text-white font-body font-medium truncate" th:text="${item.courseTitle}">강좌명</p>
-                    <p class="text-gray-400 text-sm mt-0.5">
-                        <span class="material-symbols-outlined text-xs">person</span>
-                        <span th:text="${item.instructorName}">강사명</span>
-                    </p>
-                </div>
-                <p class="ow-font-italic text-lg text-ow-blue ml-6 flex-shrink-0"
-                   th:text="${#numbers.formatInteger(item.itemPriceAtPurchase, 3, 'COMMA')} + '원'">-</p>
+    <div class="info-card blue">
+        <p class="card-title"><span class="material-symbols-outlined" style="color:#00B4FF;">school</span> Acquired Protocols</p>
+        <div th:each="item : ${detail.items}" class="course-row">
+            <div>
+                <p class="course-row-title" th:text="${item.courseTitle}">강좌명</p>
+                <p class="course-row-instructor">
+                    <span class="material-symbols-outlined" style="font-size:11px;">person</span>
+                    <span th:text="${item.instructorName}">강사명</span>
+                </p>
             </div>
+            <p class="course-row-price" th:text="${#numbers.formatInteger(item.itemPriceAtPurchase, 3, 'COMMA')} + '원'">-</p>
         </div>
     </div>
 
     <!-- 환불 섹션 -->
-    <div class="ow-card p-6"
-         th:classappend="${detail.refund != null} ? 'ow-card-red' : 'ow-card-red'">
-        <h3 class="ow-font-italic text-xl text-red-400 mb-4 flex items-center gap-2">
-            <span class="material-symbols-outlined">currency_exchange</span> REFUND STATUS
-        </h3>
+    <div class="info-card red">
+        <p class="card-title"><span class="material-symbols-outlined" style="color:#ef4444;">currency_exchange</span> Refund Status</p>
 
-        <!-- 환불 내역 없음 → 요청 폼 -->
+        <!-- 환불 요청 폼 -->
         <div th:if="${detail.refund == null}">
-            <p class="font-body text-sm text-gray-400 mb-4">환불이 필요한 경우 아래에 사유를 입력하십시오. 관리자 검토 후 처리됩니다.</p>
+            <p class="font-body text-sm text-gray-500 mb-4">환불이 필요한 경우 아래에 사유를 입력하십시오. 관리자 검토 후 처리됩니다.</p>
             <form th:action="@{/student/payments/{id}/refund(id=${detail.payment.paymentId})}"
-                  th:object="${refundRequest}" method="post" class="flex flex-col gap-3">
-                <textarea th:field="*{refundReason}"
-                          rows="3"
+                  th:object="${refundRequest}" method="post">
+                <textarea th:field="*{refundReason}" rows="3"
                           placeholder="환불 사유를 입력하십시오..."
-                          class="w-full bg-black/40 border border-gray-700 focus:border-ow-orange text-white font-body text-sm p-3 rounded resize-none outline-none transition-colors placeholder-gray-600"></textarea>
-                <div class="flex justify-end">
-                    <button type="submit"
-                            class="ow-font-italic text-sm px-8 py-3 border border-red-500 hover:bg-red-500/20 text-red-400 transition-colors cursor-pointer">
-                        환불 요청 &gt;
-                    </button>
+                          class="refund-textarea mb-3"></textarea>
+                <div style="display:flex; justify-content:flex-end;">
+                    <button type="submit" class="refund-submit">환불 요청 &gt;</button>
                 </div>
             </form>
         </div>
 
-        <!-- 환불 내역 있음 → 상태 표시 -->
+        <!-- 상태 표시 -->
         <div th:if="${detail.refund != null}" class="font-body text-sm">
-            <div class="grid grid-cols-2 gap-4 mb-4">
+            <div class="info-grid" style="margin-bottom:14px;">
                 <div>
-                    <p class="text-gray-500 mb-1">처리 상태</p>
-                    <span th:switch="${detail.refund.refundStatus.name()}">
-                        <span th:case="'REQUESTED'" class="inline-block px-3 py-1 bg-yellow-500/20 border border-yellow-500/40 text-yellow-400 rounded text-xs font-bold">검토 중</span>
-                        <span th:case="'APPROVED'"  class="inline-block px-3 py-1 bg-green-500/20 border border-green-500/40 text-green-400 rounded text-xs font-bold">승인됨</span>
-                        <span th:case="'REJECTED'"  class="inline-block px-3 py-1 bg-red-500/20 border border-red-500/40 text-red-400 rounded text-xs font-bold">거절됨</span>
-                    </span>
+                    <p class="info-label">처리 상태</p>
+                    <div style="margin-top:6px;">
+                        <span th:switch="${detail.refund.refundStatus.name()}">
+                            <span th:case="'REQUESTED'" class="status-badge badge-requested">검토 중</span>
+                            <span th:case="'APPROVED'"  class="status-badge badge-approved">승인됨</span>
+                            <span th:case="'REJECTED'"  class="status-badge badge-rejected">거절됨</span>
+                        </span>
+                    </div>
                 </div>
                 <div>
-                    <p class="text-gray-500 mb-1">요청 일시</p>
-                    <p class="text-white" th:text="${#temporals.format(detail.refund.refundRequestedAt, 'yyyy-MM-dd HH:mm')}">-</p>
+                    <p class="info-label">요청 일시</p>
+                    <p class="info-value" th:text="${#temporals.format(detail.refund.refundRequestedAt, 'yyyy-MM-dd HH:mm')}">-</p>
                 </div>
                 <div th:if="${detail.refund.refundProcessedAt != null}">
-                    <p class="text-gray-500 mb-1">처리 일시</p>
-                    <p class="text-white" th:text="${#temporals.format(detail.refund.refundProcessedAt, 'yyyy-MM-dd HH:mm')}">-</p>
+                    <p class="info-label">처리 일시</p>
+                    <p class="info-value" th:text="${#temporals.format(detail.refund.refundProcessedAt, 'yyyy-MM-dd HH:mm')}">-</p>
                 </div>
             </div>
             <div th:if="${detail.refund.refundReason != null and !detail.refund.refundReason.isEmpty()}">
-                <p class="text-gray-500 mb-1">환불 사유</p>
-                <p class="text-gray-300 bg-black/30 rounded p-3" th:text="${detail.refund.refundReason}">-</p>
+                <p class="info-label" style="margin-bottom:6px;">환불 사유</p>
+                <div style="background:rgba(0,0,0,.3); border:1px solid rgba(255,255,255,.07); border-radius:3px; padding:12px; font-size:13px; color:#9ca3af; line-height:1.6;"
+                     th:text="${detail.refund.refundReason}">-</div>
             </div>
         </div>
     </div>
-
 </main>
-
 </body>
 </html>

--- a/src/main/resources/templates/student/payment-list.html
+++ b/src/main/resources/templates/student/payment-list.html
@@ -12,20 +12,7 @@
     <script id="tailwind-config">
         tailwind.config = {
             darkMode: "class",
-            theme: {
-                extend: {
-                    colors: {
-                        "ow-orange": "#FF9C00",
-                        "ow-orange-hover": "#FFB84D",
-                        "ow-blue": "#00B4FF",
-                        "ow-dark": "#1D2127",
-                    },
-                    fontFamily: {
-                        "ow": ["Oswald", "sans-serif"],
-                        "body": ["Noto Sans KR", "sans-serif"],
-                    }
-                },
-            },
+            theme: { extend: { colors: { "ow-orange": "#FF9C00", "ow-orange-hover": "#FFB84D", "ow-blue": "#00B4FF" }, fontFamily: { "ow": ["Oswald", "sans-serif"], "body": ["Noto Sans KR", "sans-serif"] } } }
         }
     </script>
 
@@ -34,30 +21,73 @@
         .bg-sci-fi {
             position: fixed; inset: 0; z-index: -3;
             background-image: radial-gradient(circle at 30% 50%, rgba(0,0,0,.2) 0%, rgba(0,0,0,.9) 100%),
-                              url("https://images.unsplash.com/photo-1541701494587-cb58502866ab?q=80&w=2070&auto=format&fit=crop");
+            url("https://images.unsplash.com/photo-1541701494587-cb58502866ab?q=80&w=2070&auto=format&fit=crop");
             background-size: cover; background-position: center;
         }
-        .bg-overlay {
-            position: fixed; inset: 0; z-index: -2;
-            background: linear-gradient(90deg, rgba(11,14,20,1) 0%, rgba(11,14,20,.8) 30%, transparent 100%);
-        }
+        .bg-overlay { position: fixed; inset: 0; z-index: -2; background: linear-gradient(90deg, rgba(11,14,20,1) 0%, rgba(11,14,20,.8) 30%, transparent 100%); }
         .ow-font-italic { font-family: 'Oswald', sans-serif; font-style: italic; text-transform: uppercase; }
-        .ow-card {
-            background: rgba(29,33,39,.6); backdrop-filter: blur(15px);
-            border: 1px solid rgba(255,255,255,.1); border-left: 6px solid rgba(255,255,255,.2);
-            clip-path: polygon(0 0,100% 0,100% calc(100% - 16px),calc(100% - 16px) 100%,0 100%);
-            transition: border-left-color .25s ease, background .25s ease;
-        }
-        .ow-card:hover { background: rgba(40,45,55,.95); border-left-color: #FF9C00; }
         .material-symbols-outlined { font-variation-settings: 'FILL' 1,'wght' 400,'GRAD' 0,'opsz' 24; vertical-align: middle; }
+
+        /* 결제 카드 */
+        .payment-card {
+            background: rgba(29,33,39,.75); backdrop-filter: blur(16px);
+            border: 1px solid rgba(255,255,255,.08); border-radius: 4px;
+            border-left: 3px solid rgba(255,255,255,.1);
+            padding: 18px 22px;
+            margin-bottom: 10px;
+            display: flex; align-items: center; gap: 18px;
+            transition: border-left-color .2s, background .2s;
+        }
+        .payment-card:hover { background: rgba(40,45,55,.9); border-left-color: #FF9C00; }
+
+        .payment-icon {
+            width: 42px; height: 42px; flex-shrink: 0;
+            background: rgba(255,156,0,.08); border: 1px solid rgba(255,156,0,.15);
+            border-radius: 4px;
+            display: flex; align-items: center; justify-content: center;
+        }
+        .payment-icon span { color: #FF9C00; font-size: 20px; }
+
+        .payment-order-no { font-family: 'Oswald', sans-serif; font-style: italic; font-size: 15px; color: #e5e7eb; margin-bottom: 4px; }
+        .payment-meta { font-size: 12px; color: #6b7280; }
+        .payment-meta .sep { margin: 0 6px; color: rgba(255,255,255,.1); }
+        .payment-amount { font-family: 'Oswald', sans-serif; font-style: italic; font-size: 20px; font-weight: 700; color: #00B4FF; white-space: nowrap; flex-shrink: 0; }
+
+        /* 상태 뱃지 */
+        .status-badge {
+            font-family: 'Oswald', sans-serif; font-style: italic;
+            display: inline-block; padding: 4px 10px; font-size: 11px; font-weight: 600;
+            white-space: nowrap; flex-shrink: 0; letter-spacing: .5px;
+        }
+        .badge-requested { background: rgba(234,179,8,.1); border: 1px solid rgba(234,179,8,.3); color: #fbbf24; }
+        .badge-approved  { background: rgba(34,197,94,.1);  border: 1px solid rgba(34,197,94,.3);  color: #4ade80; }
+        .badge-rejected  { background: rgba(255,255,255,.05); border: 1px solid rgba(255,255,255,.1); color: #6b7280; }
+
+        /* 환불 버튼 */
+        .refund-btn {
+            font-family: 'Oswald', sans-serif; font-style: italic;
+            padding: 4px 12px; font-size: 11px; font-weight: 600; letter-spacing: .5px;
+            border: 1px solid rgba(239,68,68,.4); color: #f87171;
+            background: rgba(239,68,68,.06); cursor: pointer;
+            transition: all .15s; white-space: nowrap;
+        }
+        .refund-btn:hover { background: rgba(239,68,68,.15); border-color: #ef4444; }
+        .refund-btn:disabled { opacity: .5; cursor: not-allowed; }
+
+        /* 빈 목록 */
+        .empty-card { background: rgba(29,33,39,.75); backdrop-filter: blur(16px); border: 1px solid rgba(255,255,255,.08); border-radius: 4px; padding: 80px 24px; text-align: center; }
+
+        /* 알림 */
+        .alert-success { background: rgba(34,197,94,.08); border: 1px solid rgba(34,197,94,.25); color: #86efac; padding: 13px 16px; border-radius: 4px; font-size: 13px; margin-bottom: 16px; }
+        .alert-error   { background: rgba(239,68,68,.08); border: 1px solid rgba(239,68,68,.25); color: #fca5a5; padding: 13px 16px; border-radius: 4px; font-size: 13px; margin-bottom: 16px; }
     </style>
 </head>
 
 <body class="min-h-screen relative">
-
 <div class="bg-sci-fi"></div>
 <div class="bg-overlay"></div>
 
+<!-- ── 헤더 ── -->
 <header class="fixed top-0 left-0 right-0 z-50 flex justify-between items-start p-6 pointer-events-none">
     <div class="pointer-events-auto">
         <h1 class="ow-font-italic text-5xl font-bold text-white tracking-wider drop-shadow-[0_2px_10px_rgba(0,0,0,0.8)]">
@@ -65,7 +95,6 @@
         </h1>
         <p class="font-body text-xs text-gray-400 tracking-widest mt-1">ALIEN UNIVERSE LEARNING PLATFORM</p>
     </div>
-
     <div class="pointer-events-auto flex items-stretch bg-white text-black rounded-sm shadow-[0_5px_20px_rgba(0,0,0,0.6)] overflow-hidden" th:if="${loginMember != null}">
         <div class="bg-gray-200 px-4 py-2 flex items-center justify-center border-r border-gray-300">
             <span class="material-symbols-outlined text-gray-700 text-4xl">account_circle</span>
@@ -80,107 +109,75 @@
     </div>
 </header>
 
+<!-- ── 메인 ── -->
 <main class="min-h-screen max-w-5xl mx-auto px-6 pt-36 pb-16">
-
     <div class="mb-8 flex items-center justify-between">
         <h2 class="ow-font-italic text-4xl font-bold text-white tracking-wide flex items-center gap-3">
             <span class="text-ow-orange">></span>
             PAYMENT LOG <span class="text-gray-600 text-xl font-normal">// 자원 소모 기록</span>
         </h2>
-        <a th:href="@{/student}" class="font-body text-sm text-gray-400 hover:text-ow-orange transition-colors">
-            &larr; 학생 홈
-        </a>
+        <a th:href="@{/student}" class="font-body text-sm text-gray-400 hover:text-ow-orange transition-colors">← 학생 홈</a>
     </div>
 
-    <!-- 알림 -->
-    <div th:if="${successMsg}" class="mb-6 p-4 bg-green-900/40 border border-green-500/40 text-green-300 font-body text-sm rounded"
-         th:text="${successMsg}"></div>
-    <div th:if="${errorMsg}" class="mb-6 p-4 bg-red-900/40 border border-red-500/40 text-red-300 font-body text-sm rounded"
-         th:text="${errorMsg}"></div>
+    <div th:if="${successMsg}" class="alert-success" th:text="${successMsg}"></div>
+    <div th:if="${errorMsg}"   class="alert-error"   th:text="${errorMsg}"></div>
 
-    <!-- 결제 내역 없음 -->
-    <div th:if="${#lists.isEmpty(payments)}" class="ow-card p-16 text-center">
+    <!-- 빈 목록 -->
+    <div th:if="${#lists.isEmpty(payments)}" class="empty-card">
         <span class="material-symbols-outlined text-6xl text-gray-600 mb-4 block">receipt_long</span>
         <p class="ow-font-italic text-2xl text-gray-500">NO TRANSACTIONS</p>
         <p class="font-body text-sm text-gray-600 mt-2">아직 결제 내역이 없습니다.</p>
     </div>
 
     <!-- 결제 목록 -->
-    <div th:if="${!#lists.isEmpty(payments)}" class="flex flex-col gap-4">
-        <div th:each="payment : ${payments}" class="ow-card p-6 flex items-center gap-5">
+    <div th:if="${!#lists.isEmpty(payments)}">
+        <div th:each="payment : ${payments}" class="payment-card">
 
             <!-- 아이콘 -->
-            <div class="flex-shrink-0">
-                <span class="material-symbols-outlined text-4xl text-gray-500">receipt_long</span>
+            <div class="payment-icon">
+                <span class="material-symbols-outlined">receipt_long</span>
             </div>
 
-            <!-- 주문 정보 (클릭 시 상세 이동) -->
+            <!-- 주문 정보 (클릭 → 상세) -->
             <a th:href="@{/student/payments/{id}(id=${payment.paymentId})}"
-               class="flex-1 min-w-0 hover:text-ow-orange transition-colors group">
-                <p class="ow-font-italic text-lg text-white group-hover:text-ow-orange transition-colors truncate"
-                   th:text="${payment.paymentOrderNo}">ORD-20260414-XXXXXXXX</p>
-                <p class="font-body text-sm text-gray-400 mt-1">
+               style="flex:1; min-width:0; text-decoration:none;">
+                <p class="payment-order-no hover:text-ow-orange transition-colors" th:text="${payment.paymentOrderNo}">ORD-20260414</p>
+                <div class="payment-meta">
                     <span th:text="${payment.itemCount} + '개 강좌'">0개 강좌</span>
-                    <span class="mx-2 text-gray-600">|</span>
+                    <span class="sep">|</span>
                     <span th:text="${#temporals.format(payment.paymentCompletedAt, 'yyyy-MM-dd HH:mm')}">날짜</span>
-                </p>
+                </div>
             </a>
 
             <!-- 결제 금액 -->
-            <div class="flex-shrink-0 text-right mr-2">
-                <p class="ow-font-italic text-2xl font-bold text-ow-blue"
-                   th:text="${#numbers.formatInteger(payment.paymentTotalPrice, 3, 'COMMA')} + '원'">0원</p>
-            </div>
+            <p class="payment-amount" th:text="${#numbers.formatInteger(payment.paymentTotalPrice, 3, 'COMMA')} + '원'">0원</p>
 
             <!-- 환불 영역 -->
-            <div class="flex-shrink-0 w-28 flex justify-end">
-
-                <!-- 환불 내역 없음 → 환불 요청 버튼 -->
+            <div style="flex-shrink:0; min-width:80px; text-align:right;">
                 <form th:if="${payment.refundStatus == null}"
                       th:action="@{/student/payments/{id}/refund(id=${payment.paymentId})}"
-                      method="post"
-                      class="refund-form">
+                      method="post" class="refund-form" style="display:inline;">
                     <input type="hidden" name="refundReason" value=""/>
-                    <button type="submit"
-                            class="refund-btn ow-font-italic text-xs px-4 py-2 border border-red-500/60 hover:border-red-400 hover:bg-red-500/10 text-red-400 transition-colors cursor-pointer whitespace-nowrap">
-                        환불 신청
-                    </button>
+                    <button type="submit" class="refund-btn">환불 신청</button>
                 </form>
-
-                <!-- 환불 요청됨 → 상태 배지 (버튼 없음) -->
-                <div th:if="${payment.refundStatus != null}" class="text-right">
+                <div th:if="${payment.refundStatus != null}">
                     <span th:switch="${payment.refundStatus.name()}">
-                        <span th:case="'REQUESTED'"
-                              class="ow-font-italic text-xs px-3 py-1.5 bg-yellow-500/10 border border-yellow-500/40 text-yellow-400 whitespace-nowrap">
-                            검토 중
-                        </span>
-                        <span th:case="'APPROVED'"
-                              class="ow-font-italic text-xs px-3 py-1.5 bg-green-500/10 border border-green-500/40 text-green-400 whitespace-nowrap">
-                            승인됨
-                        </span>
-                        <span th:case="'REJECTED'"
-                              class="ow-font-italic text-xs px-3 py-1.5 bg-gray-500/10 border border-gray-500/40 text-gray-400 whitespace-nowrap">
-                            거절됨
-                        </span>
+                        <span th:case="'REQUESTED'" class="status-badge badge-requested">검토 중</span>
+                        <span th:case="'APPROVED'"  class="status-badge badge-approved">승인됨</span>
+                        <span th:case="'REJECTED'"  class="status-badge badge-rejected">거절됨</span>
                     </span>
                 </div>
-
             </div>
-
         </div>
     </div>
-
 </main>
 
 <script>
-    // 환불 신청 버튼: 클릭 즉시 "검토 중" 비활성화 상태로 전환한 뒤 폼 제출
     document.querySelectorAll('.refund-form').forEach(function(form) {
-        form.addEventListener('submit', function() {
+        form.addEventListener('submit', function(e) {
+            if (!confirm('환불을 신청하시겠습니까? 관리자 검토 후 처리됩니다.')) { e.preventDefault(); return; }
             var btn = form.querySelector('.refund-btn');
-            btn.textContent = '검토 중';
-            btn.disabled = true;
-            btn.classList.remove('border-red-500/60', 'hover:border-red-400', 'hover:bg-red-500/10', 'text-red-400', 'cursor-pointer');
-            btn.classList.add('border-yellow-500/40', 'text-yellow-400', 'cursor-not-allowed', 'opacity-70');
+            btn.textContent = '검토 중'; btn.disabled = true;
         });
     });
 </script>


### PR DESCRIPTION
## 관련 이슈
Closes #77 

## 작업 브랜치
- ex) feature/paymentfinall

## 작업 목적
- payment ui 수

## 변경 사항
cart/ payment-detail/ payment ui 수정

### 상세 변경 내용
cart.html
레이아웃 변경: 하단 고정 결제 패널 → 좌우 2단 레이아웃 (강좌 목록 | 우측 sticky 결제 패널)
강좌 카드 선택 강조 방식 변경: clip-path 스타일 → 왼쪽 컬러 보더
삭제 버튼 변경: 텍스트 "삭제" → X 아이콘
결제 패널 간소화: 쿠폰 / 포인트 / 할인 금액 섹션 제거, 강좌 금액 → 결제 금액 → 결제하기 버튼만 유지

payments.html

카드 호버 시 왼쪽 주황 보더 강조 추가
환불 신청 버튼 클릭 시 confirm() 다이얼로그 추가 (실수 방지)
상태 뱃지 스타일 정리 (검토 중 / 승인됨 / 거절됨)

payment-detail.html

섹션 카드 3개로 구조 분리: 결제 정보(주황) / 구매 강좌(파랑) / 환불(빨강)
카드별 왼쪽 컬러 라인으로 시각 구분
정보 항목 그리드 레이아웃으로 정렬

공통

배경 이미지, 오버레이, 헤더 유지
Oswald italic 폰트, #FF9C00, #00B4FF 색상 유지
Thymeleaf 변수 및 문법 변경 없음
## 테스트 내용
- [ ] 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] 로컬 실행 확인

