### PR TITLE
payment 대조

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/payment/client/TossPaymentClient.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/payment/client/TossPaymentClient.java
@@ -1,5 +1,6 @@
 package com.wanted.ailienlmsprogram.payment.client;
 
+import com.wanted.ailienlmsprogram.payment.dto.TossPaymentResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -29,8 +30,10 @@ public class TossPaymentClient {
     /**
      * POST /v1/payments/confirm
      * 결제 승인: 클라이언트 SDK가 반환한 paymentKey, orderId, amount로 서버 측 최종 승인.
+     *
+     * @return
      */
-    public void confirm(String paymentKey, String orderId, long amount) {
+    public TossPaymentResponse confirm(String paymentKey, String orderId, long amount) {
         Map<String, Object> body = Map.of(
                 "paymentKey", paymentKey,
                 "orderId",    orderId,
@@ -38,13 +41,14 @@ public class TossPaymentClient {
         );
 
         try {
-            restClient.post()
+            return restClient.post()
                     .uri("https://api.tosspayments.com/v1/payments/confirm")
                     .header("Authorization", basicAuth())
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(body)
                     .retrieve()
-                    .toBodilessEntity();
+                    .body(TossPaymentResponse.class); // 토스 결과값
+
         } catch (RestClientException e) {
             log.error("Toss confirm failed: paymentKey={}, orderId={}", paymentKey, orderId, e);
             throw new IllegalArgumentException("토스페이먼츠 결제 확인에 실패했습니다.");
@@ -85,4 +89,5 @@ public class TossPaymentClient {
         return "Basic " + Base64.getEncoder()
                 .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
     }
+
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/payment/dto/TossPaymentResponse.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/payment/dto/TossPaymentResponse.java
@@ -1,0 +1,15 @@
+package com.wanted.ailienlmsprogram.payment.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TossPaymentResponse {
+    private String paymentKey;    // Toss 결제 고유키
+    private String orderId;       // 우리가 만든 주문번호
+    private int totalAmount;      // 실제 결제된 금액
+    private String status;        // "DONE" 이면 성공
+    private String approvedAt;    // 실제 승인 시각
+    private String method;        // 카드, 네이버페이 등
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/payment/service/PaymentService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/payment/service/PaymentService.java
@@ -6,6 +6,7 @@ import com.wanted.ailienlmsprogram.member.entity.Member;
 import com.wanted.ailienlmsprogram.payment.client.TossPaymentClient;
 import com.wanted.ailienlmsprogram.payment.dto.PaymentDetailResponse;
 import com.wanted.ailienlmsprogram.payment.dto.PaymentSummaryResponse;
+import com.wanted.ailienlmsprogram.payment.dto.TossPaymentResponse;
 import com.wanted.ailienlmsprogram.payment.entity.Cart;
 import com.wanted.ailienlmsprogram.payment.entity.Payment;
 import com.wanted.ailienlmsprogram.payment.entity.PaymentItem;
@@ -131,8 +132,25 @@ public class PaymentService {
                     "결제 금액이 일치하지 않습니다. (예상: " + expectedAmount + "원, 수신: " + amount + "원)");
         }
 
-        // 3. 토스페이먼츠 서버 측 결제 확인 (금액 검증 통과 후 호출)
-        tossPaymentClient.confirm(paymentKey, orderId, amount);
+
+        // 3. 토스페이먼츠 서버 측 결제 확인 (금액 검증 통과 후 1회만 호출)
+        TossPaymentResponse response = tossPaymentClient.confirm(paymentKey, orderId, amount);
+
+        if (response == null) {
+            throw new IllegalArgumentException("토스페이먼츠 응답을 받지 못했습니다.");
+        }
+        if (!"DONE".equals(response.getStatus())) {
+            throw new IllegalArgumentException("결제가 완료되지 않았습니다. (status: " + response.getStatus() + ")");
+        }
+        if (response.getTotalAmount() != expectedAmount) {
+            throw new IllegalArgumentException("Toss 응답 금액이 일치하지 않습니다.");
+        }
+        if (!response.getOrderId().equals(orderId)) {
+            throw new IllegalArgumentException("Toss 응답 주문번호가 일치하지 않습니다.");
+        }
+
+
+
 
         // 4. Payment 생성
         Payment payment = new Payment();
@@ -142,6 +160,8 @@ public class PaymentService {
         payment.setPaymentTotalPrice(expectedAmount);
         payment.setPaymentCompletedAt(LocalDateTime.now());
         paymentRepository.save(payment);
+
+
 
         // 5. PaymentItem 생성 + 수강 등록
         for (Cart cart : cartItems) {


### PR DESCRIPTION
## 관련 이슈
Closes #82 

## 작업 브랜치
- ex) feature/paymentfinall

## 작업 목적
- Toss confirm API 응답값을 DB와 이중 검증하는 로직이 없어서 결제 위변조 완전 차단이 불가능했음
- TossPaymentClient.confirm()에서 응답을 변수에 담지 않아 null 반환하는 버그 수정

## 변경 사항
- payment 패키지
- TossPaymentClient / PaymentService

### 상세 변경 내용
1. TossPaymentClient.confirm() 반환 타입 void → TossPaymentResponse로 변경, null 체크 추가
2. confirm() 중복 호출 3회 → 1회로 정리
3. confirmTossPayment()에서 Toss 응답값 이중 검증 추가 (status DONE 확인, totalAmount DB 대조, orderId 일치 확인) + 실제 Toss 승인 시각(approvedAt)으로 저장
## 테스트 내용
- [x] 정상 동작 확인 — Toss 테스트 결제 완료 후 결제 내역 정상 저장
- [x] 예외 케이스 확인 — Toss 응답 금액 불일치 시 예외 발생
- [x] 로컬 실행 확인

