### PR TITLE
이태연 강좌 상세 입장 시 강좌 목록 및 대륙 내 강좌 조회 페이지 리펙토링

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/continent/service/ContinentService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/continent/service/ContinentService.java
@@ -36,6 +36,7 @@ public class ContinentService {
                 .collect(Collectors.toList());
     }
 
+    // 대륙 상세 조회
     public ContinentAllResponseDTO getContinentDetail(Long continentId) {
 
         Continent continent = continentRepository.findById(continentId)

--- a/src/main/java/com/wanted/ailienlmsprogram/coursecommand/controller/CourseCommandController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursecommand/controller/CourseCommandController.java
@@ -10,6 +10,8 @@ import com.wanted.ailienlmsprogram.coursecommand.dto.CourseFindDTO;
 import com.wanted.ailienlmsprogram.coursecommand.entity.CourseStatus;
 import com.wanted.ailienlmsprogram.coursecommand.service.CourseCommandService;
 import com.wanted.ailienlmsprogram.global.security.CustomUserDetails;
+import com.wanted.ailienlmsprogram.lecture.dto.LectureResponseDTO;
+import com.wanted.ailienlmsprogram.lecture.service.LectureService;
 import lombok.AllArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -32,6 +34,7 @@ public class CourseCommandController {
 
     private final ContinentService continentService;
     private final CourseCommandService courseCommandService;
+    private final LectureService lectureService;
 
     // 강좌 등록 페이지로 이동
     @GetMapping("/instructor/courses/apply")
@@ -63,7 +66,10 @@ public class CourseCommandController {
 
         CourseDetailResponseDTO course = courseCommandService.courseDetail(courseId);
 
+        List<LectureResponseDTO> lectures = lectureService.lectureByCourse(courseId);
+
         model.addAttribute("course" ,course);
+        model.addAttribute("lectures", lectures);
 
         return "course/detail";
     }

--- a/src/main/java/com/wanted/ailienlmsprogram/coursecommand/dao/CourseRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursecommand/dao/CourseRepository.java
@@ -12,7 +12,9 @@ import java.util.List;
 @Repository
 public interface CourseRepository extends JpaRepository<Course,Long> {
 
-    List<Course> findByContinent_ContinentId(Long continentId);
+    // 활성화 상태 쿼리문 추가
+    @Query("SELECT c FROM Course c JOIN FETCH c.continent WHERE c.continent.continentId = :continentId AND c.courseStatus = 'PUBLISHED'")
+    List<Course> findByContinent_ContinentId(@Param("continentId") Long continentId);
 
     // 상태별 조회 (공개/비공개 필터용)
     List<Course> findByInstructor_MemberIdAndCourseStatus(Long memberId, CourseStatus courseStatus);

--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/controller/LectureController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/controller/LectureController.java
@@ -32,4 +32,6 @@ public class LectureController {
         return mv;
     }
 
+
+
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/dto/LectureResponseDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/dto/LectureResponseDTO.java
@@ -1,0 +1,23 @@
+package com.wanted.ailienlmsprogram.lecture.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.checkerframework.checker.units.qual.N;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class LectureResponseDTO {
+
+    private Long courseId;
+
+    private Long lectureId;
+    private String lectureTitle;
+    private String lectureDescription;
+    private Integer lectureOrderIndex;
+
+
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/service/LectureService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/service/LectureService.java
@@ -2,6 +2,7 @@ package com.wanted.ailienlmsprogram.lecture.service;
 
 import com.wanted.ailienlmsprogram.lecture.dao.LectureRepository;
 import com.wanted.ailienlmsprogram.lecture.dto.LectureFindDTO;
+import com.wanted.ailienlmsprogram.lecture.dto.LectureResponseDTO;
 import com.wanted.ailienlmsprogram.lecture.entity.Lecture;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -23,6 +24,16 @@ public class LectureService {
 
         return lectures.stream()
                 .map(lecture -> modelMapper.map(lecture, LectureFindDTO.class))
+                .collect(Collectors.toList());
+    }
+
+    // 강좌 상세 입장 시 뜨는 강의 목록
+    public List<LectureResponseDTO> lectureByCourse(Long courseId) {
+
+        List<Lecture> foundLectures = lectureRepository.findByCourse_CourseId(courseId);
+
+        return foundLectures.stream()
+                .map(lecture -> modelMapper.map(lecture, LectureResponseDTO.class))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #92 
Closes #80 

## 작업 브랜치
- feature-lty

## 작업 목적
- 사용자에게 강의 목록 보여주기 위함

## 변경 사항
- {기능} 강좌 상세 입장 시 강좌 목록
- {리펙토링} 대륙 내 강좌 조회 페이지

### 상세 변경 내용

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

