### PR TITLE
Feat/lecture delete

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/controller/LectureController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/controller/LectureController.java
@@ -20,7 +20,6 @@ import org.springframework.web.servlet.ModelAndView;
 import java.security.Principal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.servlet.ModelAndView;
 
 import java.io.IOException;
 import java.util.List;
@@ -109,4 +108,11 @@ public class LectureController {
         return "redirect:/instructor/courses/" + courseId + "/lectures";
     }
 
+    @GetMapping("/instructor/courses/{courseId}/lectures/{lectureId}/delete")
+    public String deleteLecture(@PathVariable Long courseId,
+                                @PathVariable Long lectureId) {
+        lectureService.deleteLecture(lectureId);
+
+        return "redirect:/instructor/courses/" + courseId + "/lectures";
+    }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/service/LectureService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/service/LectureService.java
@@ -126,4 +126,19 @@ public class LectureService {
                 videoUrl
         );
     }
+
+    @Transactional
+    public void deleteLecture(Long lectureId) {
+
+        // 1. 강의 조회
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다."));
+
+        // 2. GCS 영상 삭제 (영상이 있을 때만)
+        if (lecture.getVideoUrl() != null) {
+            gcsService.deleteFile(lecture.getVideoUrl());
+        }
+
+        lectureRepository.deleteById(lectureId);
+    }
 }

--- a/src/main/resources/ddl/schema.sql
+++ b/src/main/resources/ddl/schema.sql
@@ -1,0 +1,230 @@
+-- 삭제 예정 파일
+DROP DATABASE IF EXISTS module02_lms;
+CREATE DATABASE module02_lms
+DEFAULT CHARACTER SET utf8mb4
+DEFAULT COLLATE utf8mb4_unicode_ci;
+
+DROP USER IF EXISTS 'Alien'@'localhost';
+CREATE USER 'Alien'@'localhost' IDENTIFIED BY 'Alien';
+GRANT ALL PRIVILEGES ON module02_lms.* TO 'Alien'@'localhost';
+FLUSH PRIVILEGES;
+
+USE module02_lms;
+SET FOREIGN_KEY_CHECKS = 0;
+
+DROP TABLE IF EXISTS `REFUND`;
+DROP TABLE IF EXISTS `REPORT`;
+DROP TABLE IF EXISTS `LECTURE_PROGRESS`;
+DROP TABLE IF EXISTS `QNA`;
+DROP TABLE IF EXISTS `ENROLLMENT`;
+DROP TABLE IF EXISTS `CART`;
+DROP TABLE IF EXISTS `PAYMENT_ITEM`;
+DROP TABLE IF EXISTS `PAYMENT`;
+DROP TABLE IF EXISTS `CONTINENT_COMMENT`;
+DROP TABLE IF EXISTS `CONTINENT_POST`;
+DROP TABLE IF EXISTS `COURSE_NOTICE`;
+DROP TABLE IF EXISTS `LECTURE`;
+DROP TABLE IF EXISTS `COURSE`;
+DROP TABLE IF EXISTS `CONTINENT`;
+DROP TABLE IF EXISTS `MEMBER`;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+CREATE TABLE `MEMBER` (
+    `member_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `login_id` VARCHAR(50) NOT NULL,
+    `email` VARCHAR(100) NOT NULL,
+    `password` VARCHAR(255) NOT NULL,
+    `member_name` VARCHAR(50) NOT NULL,
+    `phone` VARCHAR(20) NULL,
+    `profile_image_url` VARCHAR(500) NULL,
+    `member_role` ENUM('STUDENT','INSTRUCTOR','ADMIN') NOT NULL DEFAULT 'STUDENT',
+    `member_status` ENUM('ACTIVE','INACTIVE','BANNED') NOT NULL DEFAULT 'ACTIVE',
+    `introduction` TEXT NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    `deleted_at` DATETIME NULL,
+    `member_rank` ENUM('REPTILIAN','MINERVAL','NOVICE') NULL,
+    `last_login_at` DATETIME NULL,
+    CONSTRAINT `PK_MEMBER` PRIMARY KEY (`member_id`),
+    CONSTRAINT `UK_MEMBER_LOGIN_ID` UNIQUE (`login_id`),
+    CONSTRAINT `UK_MEMBER_EMAIL` UNIQUE (`email`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `CONTINENT` (
+    `continent_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `continent_name` VARCHAR(100) NOT NULL,
+    `continent_description` TEXT NULL,
+    `continent_thumbnail_url` VARCHAR(500) NULL,
+    CONSTRAINT `PK_CONTINENT` PRIMARY KEY (`continent_id`),
+    CONSTRAINT `UK_CONTINENT_NAME` UNIQUE (`continent_name`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `COURSE` (
+    `course_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `continent_id` BIGINT NOT NULL,
+    `instructor_id` BIGINT NOT NULL,
+    `course_title` VARCHAR(200) NOT NULL,
+    `course_description` TEXT NULL,
+    `course_thumbnail_url` VARCHAR(500) NULL,
+    `course_price` INT NOT NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `course_status` ENUM('PUBLISHED','DRAFT') NULL,
+    CONSTRAINT `PK_COURSE` PRIMARY KEY (`course_id`),
+    CONSTRAINT `FK_COURSE_CONTINENT` FOREIGN KEY (`continent_id`) REFERENCES `CONTINENT` (`continent_id`),
+    CONSTRAINT `FK_COURSE_MEMBER` FOREIGN KEY (`instructor_id`) REFERENCES `MEMBER` (`member_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `LECTURE` (
+    `lecture_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `course_id` BIGINT NOT NULL,
+    `lecture_title` VARCHAR(200) NOT NULL,
+    `lecture_description` TEXT NULL,
+    `lecture_order_index` INT NOT NULL,
+    `video_url` VARCHAR(500) NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT `PK_LECTURE` PRIMARY KEY (`lecture_id`),
+    CONSTRAINT `FK_LECTURE_COURSE` FOREIGN KEY (`course_id`) REFERENCES `COURSE` (`course_id`),
+    CONSTRAINT `UK_LECTURE_COURSE_ORDER` UNIQUE (`course_id`, `lecture_order_index`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `COURSE_NOTICE` (
+    `notice_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `course_id` BIGINT NOT NULL,
+    `author_id` BIGINT NOT NULL,
+    `notice_title` VARCHAR(200) NOT NULL,
+    `notice_content` TEXT NOT NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT `PK_COURSE_NOTICE` PRIMARY KEY (`notice_id`),
+    CONSTRAINT `FK_COURSE_NOTICE_COURSE` FOREIGN KEY (`course_id`) REFERENCES `COURSE` (`course_id`),
+    CONSTRAINT `FK_COURSE_NOTICE_MEMBER` FOREIGN KEY (`author_id`) REFERENCES `MEMBER` (`member_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `CONTINENT_POST` (
+    `post_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `continent_id` BIGINT NOT NULL,
+    `author_id` BIGINT NOT NULL,
+    `post_title` VARCHAR(200) NOT NULL,
+    `post_content` TEXT NOT NULL,
+    `post_is_deleted` BOOLEAN NOT NULL DEFAULT FALSE,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `post_is_notice` BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT `PK_CONTINENT_POST` PRIMARY KEY (`post_id`),
+    CONSTRAINT `FK_CONTINENT_POST_CONTINENT` FOREIGN KEY (`continent_id`) REFERENCES `CONTINENT` (`continent_id`),
+    CONSTRAINT `FK_CONTINENT_POST_MEMBER` FOREIGN KEY (`author_id`) REFERENCES `MEMBER` (`member_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `CONTINENT_COMMENT` (
+    `comment_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `post_id` BIGINT NOT NULL,
+    `author_id` BIGINT NOT NULL,
+    `comment_content` TEXT NOT NULL,
+    `comment_is_deleted` BOOLEAN NOT NULL DEFAULT FALSE,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT `PK_CONTINENT_COMMENT` PRIMARY KEY (`comment_id`),
+    CONSTRAINT `FK_CONTINENT_COMMENT_POST` FOREIGN KEY (`post_id`) REFERENCES `CONTINENT_POST` (`post_id`),
+    CONSTRAINT `FK_CONTINENT_COMMENT_MEMBER` FOREIGN KEY (`author_id`) REFERENCES `MEMBER` (`member_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `PAYMENT` (
+    `payment_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `member_id` BIGINT NOT NULL,
+    `payment_order_no` VARCHAR(100) NOT NULL,
+    `payment_total_price` INT NOT NULL,
+    `payment_completed_at` DATETIME NULL,
+    `toss_payment_key` VARCHAR(200) NULL,
+    CONSTRAINT `PK_PAYMENT` PRIMARY KEY (`payment_id`),
+    CONSTRAINT `UK_PAYMENT_ORDER_NO` UNIQUE (`payment_order_no`),
+    CONSTRAINT `FK_PAYMENT_MEMBER` FOREIGN KEY (`member_id`) REFERENCES `MEMBER` (`member_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `PAYMENT_ITEM` (
+    `payment_item_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `payment_id` BIGINT NOT NULL,
+    `course_id` BIGINT NOT NULL,
+    `item_price_at_purchase` INT NOT NULL,
+    CONSTRAINT `PK_PAYMENT_ITEM` PRIMARY KEY (`payment_item_id`),
+    CONSTRAINT `FK_PAYMENT_ITEM_PAYMENT` FOREIGN KEY (`payment_id`) REFERENCES `PAYMENT` (`payment_id`),
+    CONSTRAINT `FK_PAYMENT_ITEM_COURSE` FOREIGN KEY (`course_id`) REFERENCES `COURSE` (`course_id`),
+    CONSTRAINT `UK_PAYMENT_ITEM_COMPOSITE` UNIQUE (`payment_id`, `course_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `CART` (
+    `cart_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `course_id` BIGINT NOT NULL,
+    `member_id` BIGINT NOT NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT `PK_CART` PRIMARY KEY (`cart_id`),
+    CONSTRAINT `FK_CART_COURSE` FOREIGN KEY (`course_id`) REFERENCES `COURSE` (`course_id`),
+    CONSTRAINT `FK_CART_MEMBER` FOREIGN KEY (`member_id`) REFERENCES `MEMBER` (`member_id`),
+    CONSTRAINT `UK_CART_COMPOSITE` UNIQUE (`course_id`, `member_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `ENROLLMENT` (
+    `enrollment_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `member_id` BIGINT NOT NULL,
+    `course_id` BIGINT NOT NULL,
+    `enrollment_status` ENUM('ACTIVE','REFUNDED') NOT NULL DEFAULT 'ACTIVE',
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `enrollment_progress_rate` DECIMAL(5,2) NULL,
+    CONSTRAINT `PK_ENROLLMENT` PRIMARY KEY (`enrollment_id`),
+    CONSTRAINT `FK_ENROLLMENT_MEMBER` FOREIGN KEY (`member_id`) REFERENCES `MEMBER` (`member_id`),
+    CONSTRAINT `FK_ENROLLMENT_COURSE` FOREIGN KEY (`course_id`) REFERENCES `COURSE` (`course_id`),
+    CONSTRAINT `UK_ENROLLMENT_MEMBER_COURSE` UNIQUE (`member_id`, `course_id`)
+) ENGINE=InnoDB;
+
+-- ✅ ON DELETE CASCADE 추가
+-- lecture 삭제 시 lecture_progress 자동 삭제
+CREATE TABLE `LECTURE_PROGRESS` (
+    `progress_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `member_id` BIGINT NOT NULL,
+    `lecture_id` BIGINT NOT NULL,
+    `progress_is_completed` BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT `PK_LECTURE_PROGRESS` PRIMARY KEY (`progress_id`),
+    CONSTRAINT `FK_PROGRESS_MEMBER` FOREIGN KEY (`member_id`) REFERENCES `MEMBER` (`member_id`),
+    CONSTRAINT `FK_PROGRESS_LECTURE` FOREIGN KEY (`lecture_id`) REFERENCES `LECTURE` (`lecture_id`) ON DELETE CASCADE,
+    CONSTRAINT `UK_PROGRESS_MEMBER_LECTURE` UNIQUE (`member_id`, `lecture_id`)
+) ENGINE=InnoDB;
+
+-- ✅ ON DELETE CASCADE 추가
+-- lecture 삭제 시 qna 자동 삭제
+CREATE TABLE `QNA` (
+    `qna_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `lecture_id` BIGINT NOT NULL,
+    `author_id` BIGINT NOT NULL,
+    `parent_id` BIGINT NULL,
+    `qna_title` VARCHAR(200) NULL,
+    `qna_content` TEXT NOT NULL,
+    `qna_is_deleted` BOOLEAN NOT NULL DEFAULT FALSE,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT `PK_QNA` PRIMARY KEY (`qna_id`),
+    CONSTRAINT `FK_QNA_LECTURE` FOREIGN KEY (`lecture_id`) REFERENCES `LECTURE` (`lecture_id`) ON DELETE CASCADE,
+    CONSTRAINT `FK_QNA_MEMBER` FOREIGN KEY (`author_id`) REFERENCES `MEMBER` (`member_id`),
+    CONSTRAINT `FK_QNA_PARENT` FOREIGN KEY (`parent_id`) REFERENCES `QNA` (`qna_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `REPORT` (
+    `report_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `reporter_id` BIGINT NOT NULL,
+    `report_target_type` ENUM('CONTINENT_POST','CONTINENT_COMMENT','QNA') NOT NULL,
+    `report_target_id` BIGINT NOT NULL,
+    `report_reason` TEXT NOT NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT `PK_REPORT` PRIMARY KEY (`report_id`),
+    CONSTRAINT `FK_REPORT_MEMBER` FOREIGN KEY (`reporter_id`) REFERENCES `MEMBER` (`member_id`),
+    INDEX `IDX_REPORT_TARGET` (`report_target_type`, `report_target_id`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `REFUND` (
+    `refund_id` BIGINT NOT NULL AUTO_INCREMENT,
+    `payment_id` BIGINT NOT NULL,
+    `member_id` BIGINT NOT NULL,
+    `refund_reason` TEXT NULL,
+    `refund_status` ENUM('REQUESTED','APPROVED','REJECTED') NOT NULL DEFAULT 'REQUESTED',
+    `refund_requested_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `refund_processed_at` DATETIME NULL,
+    CONSTRAINT `PK_REFUND` PRIMARY KEY (`refund_id`),
+    CONSTRAINT `FK_REFUND_PAYMENT` FOREIGN KEY (`payment_id`) REFERENCES `PAYMENT` (`payment_id`),
+    CONSTRAINT `FK_REFUND_MEMBER` FOREIGN KEY (`member_id`) REFERENCES `MEMBER` (`member_id`)
+) ENGINE=InnoDB;

--- a/src/main/resources/templates/lecture/find.html
+++ b/src/main/resources/templates/lecture/find.html
@@ -221,6 +221,14 @@
                             수정
                         </a>
 
+                        <!-- 삭제 버튼 -->
+                        <button type="button"
+                                th:onclick="|openDeleteModal([[${lecture.lectureId}]], [[${course.courseId}]])|"
+                                class="flex-shrink-0 flex items-center gap-1 px-3 py-1.5 rounded-lg border border-error/30 text-error/70 hover:text-error hover:border-error/50 transition-all text-xs font-label">
+                            <span class="material-symbols-outlined text-sm">delete</span>
+                            삭제
+                        </button>
+
                     </div>
                 </div>
             </div>
@@ -249,6 +257,64 @@
     <div class="absolute top-1/4 left-1/4 w-[400px] h-[400px] bg-primary/5 rounded-full blur-[120px]"></div>
     <div class="absolute bottom-1/4 right-1/4 w-[500px] h-[500px] bg-secondary/5 rounded-full blur-[150px]"></div>
 </div>
+
+<!-- ===== 삭제 확인 모달 ===== -->
+<div id="deleteModal"
+     class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+    <div class="bg-surface-container border border-outline-variant/30 rounded-2xl p-8 w-full max-w-sm shadow-2xl shadow-black/50">
+
+        <!-- 아이콘 -->
+        <div class="flex justify-center mb-4">
+            <div class="w-14 h-14 rounded-2xl bg-error/10 border border-error/20 flex items-center justify-center">
+                <span class="material-symbols-outlined text-error text-3xl">delete_forever</span>
+            </div>
+        </div>
+
+        <!-- 텍스트 -->
+        <h3 class="text-lg font-headline font-bold text-on-surface text-center mb-2">
+            강의를 삭제하시겠습니까?
+        </h3>
+        <p class="text-sm text-slate-400 font-body text-center mb-6">
+            삭제된 강의와 영상은 복구할 수 없습니다.
+        </p>
+
+        <!-- 버튼 -->
+        <div class="flex gap-3">
+            <button type="button"
+                    onclick="closeDeleteModal()"
+                    class="flex-1 py-2.5 rounded-xl bg-slate-800/50 border border-slate-700/40 text-slate-400 hover:text-white hover:border-slate-600 transition-all text-sm font-label">
+                아니오
+            </button>
+            <a id="deleteConfirmBtn"
+               href="#"
+               class="flex-1 py-2.5 rounded-xl bg-error/10 border border-error/30 text-error hover:bg-error/20 hover:border-error/50 transition-all text-sm font-label text-center">
+                예, 삭제합니다
+            </a>
+        </div>
+
+    </div>
+</div>
+
+<script>
+    function openDeleteModal(lectureId, courseId) {
+        // 삭제 확인 버튼의 href에 삭제 URL 세팅
+        document.getElementById('deleteConfirmBtn').href =
+            `/instructor/courses/${courseId}/lectures/${lectureId}/delete`;
+
+        // 모달 표시
+        document.getElementById('deleteModal').classList.remove('hidden');
+    }
+
+    function closeDeleteModal() {
+        // 모달 숨기기
+        document.getElementById('deleteModal').classList.add('hidden');
+    }
+
+    // 모달 바깥 클릭 시 닫기
+    document.getElementById('deleteModal').addEventListener('click', function(e) {
+        if (e.target === this) closeDeleteModal();
+    });
+</script>
 
 </body>
 </html>


### PR DESCRIPTION
## 관련 이슈
Closes #115 

## 작업 브랜치
- ex) feat/lectureDelete

## 작업 목적
- 강사 내 강의 삭제 기능 구현

## 변경 사항
- lecture 패키지에 삭제 메서드 구현
- db 변경

### 상세 변경 내용
1. 강사 내 강의 삭제 기능 구현
2. 강사가 내 강의를 삭제하면 DB 및 클라우드에 업데이트
3. DB에 lecture_progress 테이블이 lecture_id를 fk 로 받고있어서 삭제시 DB 반영 불가능
4. 따라서 lecture_progress의 fk 제약조건 수정 -> lecture 행 삭제시 lecture_progress 도 삭제

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

