### PR TITLE
[feat] 공지글 최상단 정렬, 공지글 댓글 차단

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/community/dto/PostDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/dto/PostDTO.java
@@ -4,6 +4,8 @@ import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import java.time.format.DateTimeFormatter; // 추가
+ // 추가
 
 @Getter
 @Setter
@@ -15,17 +17,21 @@ public class PostDTO {
     private String content;
     private String authorName;
     private String memberId;
-    // 1. 공지사항 여부 필드 추가
     private boolean postIsNotice;
+    // 작성일시 필드 추가
+    private String createdAt;
 
     public PostDTO(CommunityPost post) {
         this.postId = post.getPostId();
         this.continentId = post.getContinentId();
         this.title = post.getPostTitle();
         this.content = post.getPostContent();
-
-        // 2. 엔티티에서 데이터를 꺼내와서 DTO에 저장 (매우 중요!)
         this.postIsNotice = post.isPostIsNotice();
+
+        // 엔티티의 LocalDateTime을 "yyyy-MM-dd" 형식의 문자열로 변환
+        if (post.getCreatedAt() != null) {
+            this.createdAt = post.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        }
 
         if (post.getMember() != null) {
             this.authorName = post.getMember().getName();

--- a/src/main/java/com/wanted/ailienlmsprogram/community/dto/PostDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/dto/PostDTO.java
@@ -15,7 +15,8 @@ public class PostDTO {
     private String content;
     private String authorName;
     private String memberId;
-
+    // 1. 공지사항 여부 필드 추가
+    private boolean postIsNotice;
 
     public PostDTO(CommunityPost post) {
         this.postId = post.getPostId();
@@ -23,9 +24,12 @@ public class PostDTO {
         this.title = post.getPostTitle();
         this.content = post.getPostContent();
 
+        // 2. 엔티티에서 데이터를 꺼내와서 DTO에 저장 (매우 중요!)
+        this.postIsNotice = post.isPostIsNotice();
+
         if (post.getMember() != null) {
             this.authorName = post.getMember().getName();
-
             this.memberId = String.valueOf(post.getMember().getMemberId());
-        }   }
+        }
+    }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/community/entity/CommunityComment.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/entity/CommunityComment.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Setter
+//@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -40,5 +40,9 @@ public class CommunityComment {
     @PrePersist
     public void prePersist() {
         this.createdAt = LocalDateTime.now();
+    }
+
+    public void delete() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/community/entity/CommunityPost.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/entity/CommunityPost.java
@@ -26,11 +26,17 @@ public class CommunityPost {
     private String postTitle;
     private String postContent;
     private boolean postIsDeleted;
+    @Column(name = "post_is_notice", nullable = false)
+    private boolean postIsNotice = false;
 
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id")
     private Member member;
+
+    public void setPostIsNotice(boolean postIsNotice) {
+        this.postIsNotice = postIsNotice;
+    }
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CommunityComment> comments = new ArrayList<>();

--- a/src/main/java/com/wanted/ailienlmsprogram/community/entity/CommunityPost.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/entity/CommunityPost.java
@@ -29,6 +29,15 @@ public class CommunityPost {
     @Column(name = "post_is_notice", nullable = false)
     private boolean postIsNotice = false;
 
+    @Column(name = "created_at", updatable = false)
+    private java.time.LocalDateTime createdAt;
+
+    // 자동 날짜??
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = java.time.LocalDateTime.now();
+    }
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id")

--- a/src/main/java/com/wanted/ailienlmsprogram/community/repository/PostRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/repository/PostRepository.java
@@ -2,11 +2,16 @@ package com.wanted.ailienlmsprogram.community.repository;
 
 import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<CommunityPost, Long> {
 
-    List<CommunityPost> findByContinentIdAndPostIsDeletedFalse(Long continentId);
+    @Query("SELECT p FROM CommunityPost p " +
+            "WHERE p.continentId = :continentId AND p.postIsDeleted = false " +
+            "ORDER BY p.postIsNotice DESC, p.postId DESC")
+    List<CommunityPost> findActivePostsByContinent(@Param("continentId") Long continentId);
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/community/service/CommentService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/service/CommentService.java
@@ -64,6 +64,6 @@ public class CommentService {
             throw new IllegalStateException("본인이 작성한 댓글만 삭제할 수 있습니다.");
         }
 
-        comment.setDeleted(true);
+        comment.delete();
     }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/community/service/PostService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/service/PostService.java
@@ -6,12 +6,12 @@ import com.wanted.ailienlmsprogram.community.repository.PostRepository;
 import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -20,7 +20,8 @@ public class PostService {
     private final PostRepository postRepository;
 
     public List<PostDTO> findPostsByContinent(Long continentId) {
-        return postRepository.findByContinentIdAndPostIsDeletedFalse(continentId)
+        // 리포지토리의 @Query 메서드 호출 (공지 상단 정렬 적용됨)
+        return postRepository.findActivePostsByContinent(continentId)
                 .stream()
                 .map(PostDTO::new)
                 .collect(Collectors.toList());
@@ -29,25 +30,24 @@ public class PostService {
     public PostDTO findPostById(Long postId) {
         CommunityPost post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다. ID: " + postId));
-
         return new PostDTO(post);
     }
 
     @Transactional
     public void savePost(PostCreateRequest request, Member member) {
-        // DTO를 엔티티로 변환 (Builder 패턴 사용)
+        // 학생용 서비스이므로 postIsNotice는 무조건 false(0)로 고정!
         CommunityPost post = CommunityPost.builder()
                 .postTitle(request.getPostTitle())
                 .postContent(request.getPostContent())
                 .continentId(request.getContinentId())
-                .member(member) // 작성자(Member) 객체 연결
-                .postIsDeleted(false) // 기본값 설정
+                .member(member)
+                .postIsDeleted(false)
+                .postIsNotice(false)
                 .build();
 
         postRepository.save(post);
     }
 
-    // 2. 수정 로직 추가
     @Transactional
     public void updatePost(Long postId, PostCreateRequest request) {
         CommunityPost post = postRepository.findById(postId)
@@ -57,12 +57,11 @@ public class PostService {
         post.setPostContent(request.getPostContent());
     }
 
-    // 3. 삭제 로직 추가 (소프트 딜리트)
     @Transactional
     public void deletePost(Long postId) {
         CommunityPost post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다. ID: " + postId));
 
-        post.setPostIsDeleted(true); // 삭제 여부만 true로 변경
+        post.setPostIsDeleted(true);
     }
 }

--- a/src/main/resources/templates/community/post_detail.html
+++ b/src/main/resources/templates/community/post_detail.html
@@ -47,7 +47,7 @@
     </div>
 </div>
 
-<div class="container" style="margin-top: 50px; border-top: 1px solid #3d4450; padding-top: 30px;">
+<div class="container" th:if="${!post.postIsNotice}" style="margin-top: 50px; border-top: 1px solid #3d4450; padding-top: 30px;">
     <h3 style="color: #7ee0ff; margin-bottom: 20px;">💬 댓글</h3>
 
     <div class="comment-write" style="margin-bottom: 40px;">
@@ -59,11 +59,6 @@
                 <button type="submit" class="btn" style="background-color: #5d7cff;">댓글 등록</button>
             </div>
         </form>
-    </div>
-
-    <div th:if="${post.title.contains('[공지]')}"
-         style="background: #1e1e2d; padding: 15px; border-radius: 10px; color: #ff5f5f; margin-bottom: 30px; text-align: center;">
-        📢 공지사항에는 댓글을 작성할 수 없습니다.
     </div>
 
     <div class="comment-list">
@@ -87,6 +82,12 @@
             </div>
             <p style="color: #e0e0e0; line-height: 1.5; white-space: pre-wrap;" th:text="${comment.content}">댓글 내용</p>
         </div>
+    </div>
+</div>
+
+<div class="container" th:if="${post.postIsNotice}" style="margin-top: 50px; border-top: 1px solid #3d4450; padding-top: 30px; text-align: center;">
+    <div style="background: #1e1e2d; padding: 20px; border-radius: 10px; color: #7ee0ff;">
+        📢 <strong>안내:</strong> 공지사항에는 댓글을 작성할 수 없습니다.
     </div>
 </div>
 

--- a/src/main/resources/templates/community/posts.html
+++ b/src/main/resources/templates/community/posts.html
@@ -14,7 +14,12 @@
     .btn { display: inline-block; padding: 10px 20px; border-radius: 8px; background: #5f7cff; color: white; text-decoration: none; font-weight: bold; }
     .btn-write { background: #ffb648; color: #1d1d1d; }
     .empty-msg { text-align: center; padding: 50px; color: #b8c1e7; }
-    a { color: inherit; text-decoration: none; } /* 링크 밑줄 제거 */
+    a { color: inherit; text-decoration: none; }
+
+    /* 공지사항 전용 스타일 추가 */
+    .notice-row { background: rgba(255, 182, 72, 0.05); border-left: 4px solid #e9b6ec; }
+    .notice-badge { background: #ff5f5f; color: white; padding: 2px 6px; border-radius: 4px; font-size: 11px; margin-right: 8px; vertical-align: middle; font-weight: bold; }
+    .notice-text { color: #e9b6ec !important; font-weight: bold; }
   </style>
 </head>
 <body>
@@ -34,11 +39,21 @@
       </tr>
       </thead>
       <tbody>
-      <tr th:each="post : ${posts}">
-        <td th:text="${post.postId}">1</td>
+      <tr th:each="post : ${posts}"
+          th:onclick="|location.href='/posts/${post.postId}'|"
+          th:classappend="${post.postIsNotice} ? 'notice-row' : ''">
+
+        <td th:text="${post.postIsNotice} ? '공지' : ${post.postId}"
+            th:classappend="${post.postIsNotice} ? 'notice-text' : ''">1</td>
+
         <td>
-          <a th:href="@{/posts/{id}(id=${post.postId})}" th:text="${post.title}">게시글 제목</a>
+          <span th:if="${post.postIsNotice}" class="notice-badge">공지</span>
+
+          <a th:href="@{/posts/{id}(id=${post.postId})}"
+             th:text="${post.title}"
+             th:classappend="${post.postIsNotice} ? 'notice-text' : ''">게시글 제목</a>
         </td>
+
         <td th:text="${post.authorName}">작성자 이름</td>
       </tr>
 
@@ -50,7 +65,8 @@
   </div>
 
   <div style="margin-top: 20px; text-align: right;">
-    <a th:href="@{/continents/{id}/posts/new(id=${continentId})}" class="btn btn-write">새 글 쓰기</a>  </div>
+    <a th:href="@{/continents/{id}/posts/new(id=${continentId})}" class="btn btn-write">새 글 쓰기</a>
+  </div>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/community/posts.html
+++ b/src/main/resources/templates/community/posts.html
@@ -16,8 +16,8 @@
     .empty-msg { text-align: center; padding: 50px; color: #b8c1e7; }
     a { color: inherit; text-decoration: none; }
 
-    /* 공지사항 전용 스타일 추가 */
-    .notice-row { background: rgba(255, 182, 72, 0.05); border-left: 4px solid #e9b6ec; }
+    /* 공지사항 전용 스타일 */
+    .notice-row { background: rgba(233, 182, 236, 0.05); border-left: 4px solid #e9b6ec; }
     .notice-badge { background: #ff5f5f; color: white; padding: 2px 6px; border-radius: 4px; font-size: 11px; margin-right: 8px; vertical-align: middle; font-weight: bold; }
     .notice-text { color: #e9b6ec !important; font-weight: bold; }
   </style>
@@ -33,8 +33,7 @@
     <table class="board-table">
       <thead>
       <tr>
-        <th style="width: 10%;">번호</th>
-        <th style="width: 60%;">제목</th>
+        <th style="width: 15%;">작성일</th> <th style="width: 55%;">제목</th>
         <th style="width: 30%;">작성자</th>
       </tr>
       </thead>
@@ -43,12 +42,12 @@
           th:onclick="|location.href='/posts/${post.postId}'|"
           th:classappend="${post.postIsNotice} ? 'notice-row' : ''">
 
-        <td th:text="${post.postIsNotice} ? '공지' : ${post.postId}"
-            th:classappend="${post.postIsNotice} ? 'notice-text' : ''">1</td>
+        <td th:text="${post.postIsNotice} ? '공지' : ${post.createdAt}"
+            th:classappend="${post.postIsNotice} ? 'notice-text' : ''"
+            style="color: #b8c1e7; font-size: 14px;">2026-04-17</td>
 
         <td>
           <span th:if="${post.postIsNotice}" class="notice-badge">공지</span>
-
           <a th:href="@{/posts/{id}(id=${post.postId})}"
              th:text="${post.title}"
              th:classappend="${post.postIsNotice} ? 'notice-text' : ''">게시글 제목</a>


### PR DESCRIPTION
## 관련 이슈
Closes #102 

## 작업 브랜치
- feature/community-0416

## 작업 목적
- 공지사항의 가독성과 일반 게시글과의 차별성을 두기 위함
- 대륙별 커뮤니티의 운영 효율성을 높이기 위해 공지사항 관리 기능을 강화


## 변경 사항
- community 패키지 

### 상세 변경 내용
1. 게시판 리스트 조회 시 공지사항(true)이 최상단에 노출되도록 수정
2. 공지사항 댓글 작성 차단
3.

## 테스트 내용
- [ ] 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] 로컬 실행 확인

