### PR TITLE
feat: 관리자 통계 시각화

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminStatisticsController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminStatisticsController.java
@@ -1,0 +1,35 @@
+package com.wanted.ailienlmsprogram.admin.controller;
+
+import com.wanted.ailienlmsprogram.admin.dto.AdminContinentStatisticMetric;
+import com.wanted.ailienlmsprogram.admin.dto.AdminCourseStatisticMetric;
+import com.wanted.ailienlmsprogram.admin.dto.AdminStatisticsPageResponse;
+import com.wanted.ailienlmsprogram.admin.dto.AdminStatisticsSearchCondition;
+import com.wanted.ailienlmsprogram.admin.service.AdminStatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/admin/statics")
+public class AdminStatisticsController {
+
+    private final AdminStatisticsService adminStatisticsService;
+
+    @GetMapping
+    public String staticsPage(
+            AdminStatisticsSearchCondition condition,
+            Model model
+    ) {
+        AdminStatisticsPageResponse page = adminStatisticsService.getStatisticsPage(condition);
+
+        model.addAttribute("condition", condition);
+        model.addAttribute("page", page);
+        model.addAttribute("continentMetricValues", AdminContinentStatisticMetric.values());
+        model.addAttribute("courseMetricValues", AdminCourseStatisticMetric.values());
+
+        return "admin/statics";
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminContinentOptionResponse.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminContinentOptionResponse.java
@@ -1,0 +1,12 @@
+package com.wanted.ailienlmsprogram.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminContinentOptionResponse {
+
+    private Long continentId;
+    private String continentName;
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminContinentRankingResponse.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminContinentRankingResponse.java
@@ -1,0 +1,17 @@
+package com.wanted.ailienlmsprogram.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminContinentRankingResponse {
+
+    private Long continentId;
+    private String continentName;
+    private Long metricValue;
+
+    public Long getMetricValueOrZero() {
+        return metricValue == null ? 0L : metricValue;
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminContinentStatisticMetric.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminContinentStatisticMetric.java
@@ -1,0 +1,19 @@
+package com.wanted.ailienlmsprogram.admin.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/*대륙 랭킹 기준을 고정된 값으로 관리한다.
+*
+* Controller가 요청 파라미터를 받을 때 바인딩되고, Repository가 어떤 집계 쿼리르 탈지 분기할 때 사용한다.*/
+@Getter
+@RequiredArgsConstructor
+public enum AdminContinentStatisticMetric {
+
+    COURSE_COUNT("강좌 수 기준"),
+    STUDENT_COUNT("학생 수 기준"),
+    POST_COUNT("게시판 글 수 기준"),
+    REPORTER_COUNT("신고자 수 기준");
+
+    private final String label;
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminCourseRankingResponse.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminCourseRankingResponse.java
@@ -1,0 +1,18 @@
+package com.wanted.ailienlmsprogram.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// 선택 대륙 안의 강좌 순위 한 줄을 표현한다.
+@Getter
+@AllArgsConstructor
+public class AdminCourseRankingResponse {
+
+    private String courseTitle;
+    private String instructorName;
+    private Long metricValue;
+
+    public Long getMetricValueOrZero() {
+        return metricValue == null ? 0L : metricValue;
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminCourseStatisticMetric.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminCourseStatisticMetric.java
@@ -1,0 +1,15 @@
+package com.wanted.ailienlmsprogram.admin.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/*선택된 대륙 안에서 강좌 랭킹을 어떤 기준으로 볼지 결정한다.*/
+@Getter
+@RequiredArgsConstructor
+public enum AdminCourseStatisticMetric {
+
+    STUDENT_COUNT("학생 수 기준"),
+    QNA_COUNT("Q&A 수 기준");
+
+    private final String label;
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminStatisticsPageResponse.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminStatisticsPageResponse.java
@@ -1,0 +1,17 @@
+package com.wanted.ailienlmsprogram.admin.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AdminStatisticsPageResponse {
+
+    private List<AdminContinentOptionResponse> continentOptions;
+    private Long selectedContinentId;
+    private String selectedContinentName;
+    private List<AdminContinentRankingResponse> continentRankings;
+    private List<AdminCourseRankingResponse> courseRankings;
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminStatisticsSearchCondition.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminStatisticsSearchCondition.java
@@ -1,0 +1,14 @@
+package com.wanted.ailienlmsprogram.admin.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+// /admin/statics의 GET 파라미터를 한 객체로 묶는다.
+@Getter
+@Setter
+public class AdminStatisticsSearchCondition {
+
+    private AdminContinentStatisticMetric continentMetric = AdminContinentStatisticMetric.COURSE_COUNT;
+    private AdminCourseStatisticMetric courseMetric = AdminCourseStatisticMetric.STUDENT_COUNT;
+    private Long selectedContinentId;
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminStatisticsQueryRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminStatisticsQueryRepository.java
@@ -1,0 +1,324 @@
+package com.wanted.ailienlmsprogram.admin.repository;
+
+import com.wanted.ailienlmsprogram.admin.dto.*;
+import com.wanted.ailienlmsprogram.community.entity.CommunityComment;
+import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
+import com.wanted.ailienlmsprogram.community.entity.Report;
+import com.wanted.ailienlmsprogram.community.entity.TargetType;
+import com.wanted.ailienlmsprogram.continent.entity.Continent;
+import com.wanted.ailienlmsprogram.coursecommand.entity.Course;
+import com.wanted.ailienlmsprogram.coursecommand.entity.CourseStatus;
+import com.wanted.ailienlmsprogram.enrollment.entity.Enrollment;
+import com.wanted.ailienlmsprogram.qna.entity.Qna;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+/*실제 통계 쿼리 를 책임진다.*/
+@Repository
+public class AdminStatisticsQueryRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public List<AdminContinentOptionResponse> findContinentOptions() {
+        return em.createQuery("""
+                select new com.wanted.ailienlmsprogram.admin.dto.AdminContinentOptionResponse(
+                    c.continentId,
+                    c.continentName
+                )
+                from Continent c
+                order by c.continentName asc
+                """, AdminContinentOptionResponse.class)
+                .getResultList();
+    }
+
+    public List<AdminContinentRankingResponse> findContinentRankings(AdminContinentStatisticMetric metric) {
+        if (metric == null) {
+            metric = AdminContinentStatisticMetric.COURSE_COUNT;
+        }
+
+        return switch (metric) {
+            case COURSE_COUNT -> findContinentCourseCountRankings();
+            case STUDENT_COUNT -> findContinentStudentCountRankings();
+            case POST_COUNT -> findContinentPostCountRankings();
+            case REPORTER_COUNT -> findContinentReporterCountRankings();
+        };
+    }
+
+    public List<AdminCourseRankingResponse> findCourseRankings(Long continentId, AdminCourseStatisticMetric metric) {
+        if (continentId == null) {
+            return Collections.emptyList();
+        }
+
+        if (metric == null) {
+            metric = AdminCourseStatisticMetric.STUDENT_COUNT;
+        }
+
+        return switch (metric) {
+            case STUDENT_COUNT -> findCourseStudentCountRankings(continentId);
+            case QNA_COUNT -> findCourseQnaCountRankings(continentId);
+        };
+    }
+
+    private List<AdminContinentRankingResponse> findContinentCourseCountRankings() {
+        return em.createQuery("""
+                select new com.wanted.ailienlmsprogram.admin.dto.AdminContinentRankingResponse(
+                    ct.continentId,
+                    ct.continentName,
+                    count(distinct c.courseId)
+                )
+                from Continent ct
+                left join Course c
+                    on c.continent = ct
+                   and c.courseStatus = :publishedStatus
+                group by ct.continentId, ct.continentName
+                order by count(distinct c.courseId) desc, ct.continentName asc
+                """, AdminContinentRankingResponse.class)
+                .setParameter("publishedStatus", CourseStatus.PUBLISHED)
+                .getResultList();
+    }
+
+    private List<AdminContinentRankingResponse> findContinentStudentCountRankings() {
+        return em.createQuery("""
+                select new com.wanted.ailienlmsprogram.admin.dto.AdminContinentRankingResponse(
+                    ct.continentId,
+                    ct.continentName,
+                    count(distinct e.member.memberId)
+                )
+                from Continent ct
+                left join Course c
+                    on c.continent = ct
+                left join Enrollment e
+                    on e.course = c
+                   and e.status = :activeStatus
+                group by ct.continentId, ct.continentName
+                order by count(distinct e.member.memberId) desc, ct.continentName asc
+                """, AdminContinentRankingResponse.class)
+                .setParameter("activeStatus", Enrollment.EnrollmentStatus.ACTIVE)
+                .getResultList();
+    }
+
+    private List<AdminContinentRankingResponse> findContinentPostCountRankings() {
+        return em.createQuery("""
+                select new com.wanted.ailienlmsprogram.admin.dto.AdminContinentRankingResponse(
+                    ct.continentId,
+                    ct.continentName,
+                    count(distinct p.postId)
+                )
+                from Continent ct
+                left join CommunityPost p
+                    on p.continentId = ct.continentId
+                   and p.postIsDeleted = false
+                group by ct.continentId, ct.continentName
+                order by count(distinct p.postId) desc, ct.continentName asc
+                """, AdminContinentRankingResponse.class)
+                .getResultList();
+    }
+
+    private List<AdminContinentRankingResponse> findContinentReporterCountRankings() {
+        List<AdminContinentOptionResponse> continents = findContinentOptions();
+        Map<Long, Set<Long>> reporterSetByContinent = buildReporterSetByContinent();
+
+        List<AdminContinentRankingResponse> result = new ArrayList<>();
+
+        for (AdminContinentOptionResponse continent : continents) {
+            long reporterCount = reporterSetByContinent
+                    .getOrDefault(continent.getContinentId(), Collections.emptySet())
+                    .size();
+
+            result.add(new AdminContinentRankingResponse(
+                    continent.getContinentId(),
+                    continent.getContinentName(),
+                    reporterCount
+            ));
+        }
+
+        result.sort(Comparator
+                .comparing(AdminContinentRankingResponse::getMetricValueOrZero, Comparator.reverseOrder())
+                .thenComparing(AdminContinentRankingResponse::getContinentName));
+
+        return result;
+    }
+
+    private Map<Long, Set<Long>> buildReporterSetByContinent() {
+        List<Report> reports = em.createQuery("""
+                select r
+                from Report r
+                """, Report.class).getResultList();
+
+        if (reports.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Set<Long> postIds = new LinkedHashSet<>();
+        Set<Long> commentIds = new LinkedHashSet<>();
+        Set<Long> qnaIds = new LinkedHashSet<>();
+
+        for (Report report : reports) {
+            if (report.getTargetNo() == null) {
+                continue;
+            }
+
+            if (report.getTargetType() == TargetType.CONTINENT_POST) {
+                postIds.add(report.getTargetNo());
+            } else if (report.getTargetType() == TargetType.CONTINENT_COMMENT) {
+                commentIds.add(report.getTargetNo());
+            } else if (report.getTargetType() == TargetType.QNA) {
+                qnaIds.add(report.getTargetNo());
+            }
+        }
+
+        Map<Long, Long> postContinentMap = findPostContinentMap(postIds);
+        Map<Long, Long> commentContinentMap = findCommentContinentMap(commentIds);
+        Map<Long, Long> qnaContinentMap = findQnaContinentMap(qnaIds);
+
+        Map<Long, Set<Long>> result = new HashMap<>();
+
+        for (Report report : reports) {
+            if (report.getReporterNo() == null) {
+                continue;
+            }
+
+            Long continentId = resolveContinentId(report, postContinentMap, commentContinentMap, qnaContinentMap);
+            if (continentId == null) {
+                continue;
+            }
+
+            result.computeIfAbsent(continentId, key -> new LinkedHashSet<>())
+                    .add(report.getReporterNo());
+        }
+
+        return result;
+    }
+
+    private Map<Long, Long> findPostContinentMap(Set<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<CommunityPost> posts = em.createQuery("""
+                select p
+                from CommunityPost p
+                where p.postId in :postIds
+                """, CommunityPost.class)
+                .setParameter("postIds", postIds)
+                .getResultList();
+
+        Map<Long, Long> result = new HashMap<>();
+        for (CommunityPost post : posts) {
+            result.put(post.getPostId(), post.getContinentId());
+        }
+        return result;
+    }
+
+    private Map<Long, Long> findCommentContinentMap(Set<Long> commentIds) {
+        if (commentIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<CommunityComment> comments = em.createQuery("""
+                select distinct c
+                from CommunityComment c
+                left join fetch c.post
+                where c.commentId in :commentIds
+                """, CommunityComment.class)
+                .setParameter("commentIds", commentIds)
+                .getResultList();
+
+        Map<Long, Long> result = new HashMap<>();
+        for (CommunityComment comment : comments) {
+            Long continentId = null;
+            if (comment.getPost() != null) {
+                continentId = comment.getPost().getContinentId();
+            }
+            result.put(comment.getCommentId(), continentId);
+        }
+        return result;
+    }
+
+    private Map<Long, Long> findQnaContinentMap(Set<Long> qnaIds) {
+        if (qnaIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        List<Qna> qnas = em.createQuery("""
+                select distinct q
+                from Qna q
+                join fetch q.course c
+                join fetch c.continent ct
+                where q.qnaId in :qnaIds
+                """, Qna.class)
+                .setParameter("qnaIds", qnaIds)
+                .getResultList();
+
+        Map<Long, Long> result = new HashMap<>();
+        for (Qna qna : qnas) {
+            Long continentId = qna.getCourse().getContinent().getContinentId();
+            result.put(qna.getQnaId(), continentId);
+        }
+        return result;
+    }
+
+    private Long resolveContinentId(
+            Report report,
+            Map<Long, Long> postContinentMap,
+            Map<Long, Long> commentContinentMap,
+            Map<Long, Long> qnaContinentMap
+    ) {
+        if (report.getTargetType() == TargetType.CONTINENT_POST) {
+            return postContinentMap.get(report.getTargetNo());
+        }
+
+        if (report.getTargetType() == TargetType.CONTINENT_COMMENT) {
+            return commentContinentMap.get(report.getTargetNo());
+        }
+
+        if (report.getTargetType() == TargetType.QNA) {
+            return qnaContinentMap.get(report.getTargetNo());
+        }
+
+        return null;
+    }
+
+    private List<AdminCourseRankingResponse> findCourseStudentCountRankings(Long continentId) {
+        return em.createQuery("""
+                select new com.wanted.ailienlmsprogram.admin.dto.AdminCourseRankingResponse(
+                    c.courseTitle,
+                    c.instructor.name,
+                    count(distinct e.member.memberId)
+                )
+                from Course c
+                left join Enrollment e
+                    on e.course = c
+                   and e.status = :activeStatus
+                where c.continent.continentId = :continentId
+                group by c.courseId, c.courseTitle, c.instructor.name
+                order by count(distinct e.member.memberId) desc, c.courseTitle asc
+                """, AdminCourseRankingResponse.class)
+                .setParameter("continentId", continentId)
+                .setParameter("activeStatus", Enrollment.EnrollmentStatus.ACTIVE)
+                .getResultList();
+    }
+
+    private List<AdminCourseRankingResponse> findCourseQnaCountRankings(Long continentId) {
+        return em.createQuery("""
+                select new com.wanted.ailienlmsprogram.admin.dto.AdminCourseRankingResponse(
+                    c.courseTitle,
+                    c.instructor.name,
+                    count(q.qnaId)
+                )
+                from Course c
+                left join Qna q
+                    on q.course = c
+                   and q.qnaIsDeleted = false
+                where c.continent.continentId = :continentId
+                group by c.courseId, c.courseTitle, c.instructor.name
+                order by count(q.qnaId) desc, c.courseTitle asc
+                """, AdminCourseRankingResponse.class)
+                .setParameter("continentId", continentId)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminStatisticsService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminStatisticsService.java
@@ -1,0 +1,93 @@
+package com.wanted.ailienlmsprogram.admin.service;
+
+import com.wanted.ailienlmsprogram.admin.dto.*;
+import com.wanted.ailienlmsprogram.admin.repository.AdminStatisticsQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+/*통계 페이지에 필요한 전체 흐름을 조립한다.
+*
+* 기본 metric 세팅, 선택 대륙 없으면 첫 대륙 자동 선택 같은 화면 흐름*/
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminStatisticsService {
+
+    private final AdminStatisticsQueryRepository adminStatisticsQueryRepository;
+
+    public AdminStatisticsPageResponse getStatisticsPage(AdminStatisticsSearchCondition condition) {
+        normalizeCondition(condition);
+
+        List<AdminContinentOptionResponse> continentOptions = adminStatisticsQueryRepository.findContinentOptions();
+        Long selectedContinentId = resolveSelectedContinentId(condition.getSelectedContinentId(), continentOptions);
+        condition.setSelectedContinentId(selectedContinentId);
+
+        String selectedContinentName = findSelectedContinentName(selectedContinentId, continentOptions);
+
+        List<AdminContinentRankingResponse> continentRankings =
+                adminStatisticsQueryRepository.findContinentRankings(condition.getContinentMetric());
+
+        List<AdminCourseRankingResponse> courseRankings =
+                selectedContinentId == null
+                        ? Collections.emptyList()
+                        : adminStatisticsQueryRepository.findCourseRankings(selectedContinentId, condition.getCourseMetric());
+
+        return new AdminStatisticsPageResponse(
+                continentOptions,
+                selectedContinentId,
+                selectedContinentName,
+                continentRankings,
+                courseRankings
+        );
+    }
+
+    private void normalizeCondition(AdminStatisticsSearchCondition condition) {
+        if (condition.getContinentMetric() == null) {
+            condition.setContinentMetric(AdminContinentStatisticMetric.COURSE_COUNT);
+        }
+
+        if (condition.getCourseMetric() == null) {
+            condition.setCourseMetric(AdminCourseStatisticMetric.STUDENT_COUNT);
+        }
+    }
+
+    private Long resolveSelectedContinentId(
+            Long selectedContinentId,
+            List<AdminContinentOptionResponse> continentOptions
+    ) {
+        if (continentOptions == null || continentOptions.isEmpty()) {
+            return null;
+        }
+
+        if (selectedContinentId != null) {
+            for (AdminContinentOptionResponse option : continentOptions) {
+                if (option.getContinentId().equals(selectedContinentId)) {
+                    return selectedContinentId;
+                }
+            }
+        }
+
+        return continentOptions.get(0).getContinentId();
+    }
+
+    private String findSelectedContinentName(
+            Long selectedContinentId,
+            List<AdminContinentOptionResponse> continentOptions
+    ) {
+        if (selectedContinentId == null || continentOptions == null) {
+            return null;
+        }
+
+        for (AdminContinentOptionResponse option : continentOptions) {
+            if (option.getContinentId().equals(selectedContinentId)) {
+                return option.getContinentName();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/templates/admin/admin-home.html
+++ b/src/main/resources/templates/admin/admin-home.html
@@ -251,7 +251,7 @@
             <i class="fa-solid fa-circle-exclamation"></i>
             <span>게시판/신고 관리</span>
         </a>
-        <a th:href="@{/admin/statistics}" class="nav-item">
+        <a th:href="@{/admin/statics}" class="nav-item">
             <i class="fa-solid fa-chart-line"></i>
             <span>통계/모니터링</span>
         </a>
@@ -263,7 +263,7 @@
             <i class="fa-solid fa-book-open"></i>
             <span>강좌 신청 관리</span>
         </a>
-        <a th:href="@{/admin/continent-notices/continents}" class="nav-item">
+        <a th:href="@{/admin/continent-notices}" class="nav-item">
             <i class="fa-solid fa-bullhorn"></i>
             <span>대륙 공지 작성</span>
         </a>
@@ -319,7 +319,7 @@
                 <div class="icon-box"><i class="fa-solid fa-chart-pie"></i></div>
                 <h3>통계/모니터링</h3>
                 <p>수강률, 참여율, 결제 및 환불 통계 등 전반적인 지표를 시각화하여 확인합니다.</p>
-                <a th:href="@{/admin/statistics}" class="btn-go">관리하기 <i class="fa-solid fa-chevron-right"></i></a>
+                <a th:href="@{/admin/statics}" class="btn-go">관리하기 <i class="fa-solid fa-chevron-right"></i></a>
             </div>
 
             <div class="menu-card">

--- a/src/main/resources/templates/admin/continent-notice-list.html
+++ b/src/main/resources/templates/admin/continent-notice-list.html
@@ -186,10 +186,10 @@
             수정
           </a>
 
-          <form th:action="@{/admin/continent-notices/delete}" method="post" class="inline-form"
+          <form th:action="@{/admin/continent-notices/{postId}/delete(postId=${notice.postId}, continentId=${continent.continentId})}"
+                method="post"
+                class="inline-form"
                 onsubmit="return confirm('해당 공지글을 삭제하시겠습니까?');">
-            <input type="hidden" name="continentId" th:value="${continent.continentId}">
-            <input type="hidden" name="postId" th:value="${notice.postId}">
             <button type="submit" class="btn btn-danger">삭제</button>
           </form>
         </td>

--- a/src/main/resources/templates/admin/course-detail.html
+++ b/src/main/resources/templates/admin/course-detail.html
@@ -404,7 +404,7 @@
       <i class="fa-solid fa-circle-exclamation"></i>
       <span>게시판/신고 관리</span>
     </a>
-    <a th:href="@{/admin/statistics}" class="nav-item">
+    <a th:href="@{/admin/statics}" class="nav-item">
       <i class="fa-solid fa-chart-line"></i>
       <span>통계/모니터링</span>
     </a>
@@ -416,7 +416,7 @@
       <i class="fa-solid fa-book-open"></i>
       <span>강좌 신청 관리</span>
     </a>
-    <a th:href="@{/admin/continent-notices/continents}" class="nav-item">
+    <a th:href="@{/admin/continent-notices}" class="nav-item">
       <i class="fa-solid fa-bullhorn"></i>
       <span>대륙 공지 작성</span>
     </a>

--- a/src/main/resources/templates/admin/course-list.html
+++ b/src/main/resources/templates/admin/course-list.html
@@ -472,7 +472,7 @@
             <i class="fa-solid fa-circle-exclamation"></i>
             <span>게시판/신고 관리</span>
         </a>
-        <a th:href="@{/admin/statistics}" class="nav-item">
+        <a th:href="@{/admin/statics}" class="nav-item">
             <i class="fa-solid fa-chart-line"></i>
             <span>통계/모니터링</span>
         </a>
@@ -484,7 +484,7 @@
             <i class="fa-solid fa-book-open"></i>
             <span>강좌 신청 관리</span>
         </a>
-        <a th:href="@{/admin/continent-notices/continents}" class="nav-item">
+        <a th:href="@{/admin/continent-notices}" class="nav-item">
             <i class="fa-solid fa-bullhorn"></i>
             <span>대륙 공지 작성</span>
         </a>

--- a/src/main/resources/templates/admin/instructor-create.html
+++ b/src/main/resources/templates/admin/instructor-create.html
@@ -342,7 +342,7 @@
             <i class="fa-solid fa-circle-exclamation"></i>
             <span>게시판/신고 관리</span>
         </a>
-        <a th:href="@{/admin/statistics}" class="nav-item">
+        <a th:href="@{/admin/statics}" class="nav-item">
             <i class="fa-solid fa-chart-line"></i>
             <span>통계/모니터링</span>
         </a>
@@ -354,7 +354,7 @@
             <i class="fa-solid fa-book-open"></i>
             <span>강좌 신청 관리</span>
         </a>
-        <a th:href="@{/admin/continent-notices/continents}" class="nav-item">
+        <a th:href="@{/admin/continent-notices}" class="nav-item">
             <i class="fa-solid fa-bullhorn"></i>
             <span>대륙 공지 작성</span>
         </a>

--- a/src/main/resources/templates/admin/member-list.html
+++ b/src/main/resources/templates/admin/member-list.html
@@ -491,7 +491,7 @@
             <i class="fa-solid fa-circle-exclamation"></i>
             <span>게시판/신고 관리</span>
         </a>
-        <a th:href="@{/admin/statistics}" class="nav-item">
+        <a th:href="@{/admin/statics}" class="nav-item">
             <i class="fa-solid fa-chart-line"></i>
             <span>통계/모니터링</span>
         </a>
@@ -503,7 +503,7 @@
             <i class="fa-solid fa-book-open"></i>
             <span>강좌 신청 관리</span>
         </a>
-        <a th:href="@{/admin/continent-notices/continents}" class="nav-item">
+        <a th:href="@{/admin/continent-notices}" class="nav-item">
             <i class="fa-solid fa-bullhorn"></i>
             <span>대륙 공지 작성</span>
         </a>

--- a/src/main/resources/templates/admin/refund-list.html
+++ b/src/main/resources/templates/admin/refund-list.html
@@ -460,7 +460,7 @@
       <i class="fa-solid fa-circle-exclamation"></i>
       <span>게시판/신고 관리</span>
     </a>
-    <a th:href="@{/admin/statistics}" class="nav-item">
+    <a th:href="@{/admin/statics}" class="nav-item">
       <i class="fa-solid fa-chart-line"></i>
       <span>통계/모니터링</span>
     </a>
@@ -472,7 +472,7 @@
       <i class="fa-solid fa-book-open"></i>
       <span>강좌 신청 관리</span>
     </a>
-    <a th:href="@{/admin/continent-notices/continents}" class="nav-item">
+    <a th:href="@{/admin/continent-notices}" class="nav-item">
       <i class="fa-solid fa-bullhorn"></i>
       <span>대륙 공지 작성</span>
     </a>

--- a/src/main/resources/templates/admin/report-list.html
+++ b/src/main/resources/templates/admin/report-list.html
@@ -392,7 +392,7 @@
             <i class="fa-solid fa-circle-exclamation"></i>
             <span>게시판/신고 관리</span>
         </a>
-        <a th:href="@{/admin/statistics}" class="nav-item">
+        <a th:href="@{/admin/statics}" class="nav-item">
             <i class="fa-solid fa-chart-line"></i>
             <span>통계/모니터링</span>
         </a>
@@ -404,7 +404,7 @@
             <i class="fa-solid fa-book-open"></i>
             <span>강좌 신청 관리</span>
         </a>
-        <a th:href="@{/admin/continent-notices/continents}" class="nav-item">
+        <a th:href="@{/admin/continent-notices}" class="nav-item">
             <i class="fa-solid fa-bullhorn"></i>
             <span>대륙 공지 작성</span>
         </a>

--- a/src/main/resources/templates/admin/statics.html
+++ b/src/main/resources/templates/admin/statics.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title><!DOCTYPE html>
+      <html lang="ko" xmlns:th="http://www.thymeleaf.org">
+      <head>
+      <meta charset="UTF-8">
+      <title>대륙별 통계 | ADMIN</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #f6f8fb;
+      margin: 0;
+      color: #222;
+    }
+
+    header {
+      background: #2f3241;
+      color: white;
+      padding: 20px 32px;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: 24px;
+    }
+
+    nav {
+      margin-top: 10px;
+    }
+
+    nav a {
+      color: #ffffff;
+      text-decoration: none;
+      margin-right: 14px;
+      font-size: 14px;
+    }
+
+    .container {
+      width: 1100px;
+      max-width: calc(100% - 40px);
+      margin: 30px auto;
+    }
+
+    .panel {
+      background: white;
+      border-radius: 16px;
+      padding: 24px;
+      box-shadow: 0 6px 18px rgba(0,0,0,0.06);
+      margin-bottom: 24px;
+    }
+
+    .panel h2 {
+      margin-top: 0;
+      margin-bottom: 8px;
+    }
+
+    .desc {
+      color: #666;
+      font-size: 14px;
+      margin-bottom: 20px;
+    }
+
+    .filter-form {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: end;
+      margin-bottom: 20px;
+    }
+
+    .filter-group {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .filter-group label {
+      font-size: 13px;
+      color: #555;
+    }
+
+    select, button {
+      height: 40px;
+      padding: 0 12px;
+      border: 1px solid #d5dbe3;
+      border-radius: 10px;
+      background: white;
+    }
+
+    button {
+      background: #2f3241;
+      color: white;
+      border: none;
+      cursor: pointer;
+      min-width: 100px;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: 1.1fr 1fr;
+      gap: 20px;
+    }
+
+    .chart-box, .table-box {
+      background: #fafbfd;
+      border: 1px solid #edf1f5;
+      border-radius: 14px;
+      padding: 18px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      background: white;
+    }
+
+    th, td {
+      padding: 12px 10px;
+      border-bottom: 1px solid #eef1f4;
+      text-align: left;
+      font-size: 14px;
+    }
+
+    th {
+      background: #f8fafc;
+    }
+
+    .rank {
+      width: 70px;
+      font-weight: 700;
+    }
+
+    .empty {
+      padding: 30px 0;
+      text-align: center;
+      color: #888;
+      font-size: 14px;
+    }
+
+    .section-title {
+      margin-bottom: 4px;
+      font-size: 18px;
+      font-weight: bold;
+    }
+
+    .sub-info {
+      margin-bottom: 16px;
+      color: #666;
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+<header>
+  <h1>ADMIN PANEL</h1>
+  <nav>
+    <a th:href="@{/admin}">대시보드 홈</a>
+    <a th:href="@{/admin/members}">회원/계정 관리</a>
+    <a th:href="@{/admin/instructors/new}">강사 계정 생성</a>
+    <a th:href="@{/admin/reports}">게시판/신고 관리</a>
+    <a th:href="@{/admin/statics}">통계/모니터링</a>
+    <a th:href="@{/admin/refunds}">환불 요청 관리</a>
+    <a th:href="@{/admin/courses}">강좌 신청 관리</a>
+    <a th:href="@{/admin/continent-notices}">대륙 공지 작성</a>
+    <a th:href="@{/logout}">로그아웃</a>
+  </nav>
+</header>
+
+<div class="container">
+  <div class="panel">
+    <h2>대륙별 통계</h2>
+    <p class="desc">
+      관리자는 대륙 활성화 순위와, 선택 대륙 내 강좌 순위를 각각 다른 기준으로 조회할 수 있습니다.
+    </p>
+
+    <form class="filter-form" method="get" th:action="@{/admin/statics}" th:object="${condition}">
+      <div class="filter-group">
+        <label for="continentMetric">대륙 활성화 기준</label>
+        <select id="continentMetric" th:field="*{continentMetric}">
+          <option th:each="metric : ${continentMetricValues}"
+                  th:value="${metric}"
+                  th:text="${metric.label}">
+          </option>
+        </select>
+      </div>
+
+      <div class="filter-group">
+        <label for="selectedContinentId">강좌 순위 대륙 선택</label>
+        <select id="selectedContinentId" th:field="*{selectedContinentId}">
+          <option th:each="continent : ${page.continentOptions}"
+                  th:value="${continent.continentId}"
+                  th:text="${continent.continentName}">
+          </option>
+        </select>
+      </div>
+
+      <div class="filter-group">
+        <label for="courseMetric">강좌 순위 기준</label>
+        <select id="courseMetric" th:field="*{courseMetric}">
+          <option th:each="metric : ${courseMetricValues}"
+                  th:value="${metric}"
+                  th:text="${metric.label}">
+          </option>
+        </select>
+      </div>
+
+      <div class="filter-group">
+        <label>&nbsp;</label>
+        <button type="submit">조회하기</button>
+      </div>
+    </form>
+  </div>
+
+  <div class="panel">
+    <div class="section-title">전체 대륙 활성화 순위</div>
+    <div class="sub-info"
+         th:text="'현재 기준: ' + ${condition.continentMetric.label}">
+      현재 기준
+    </div>
+
+    <div class="grid">
+      <div class="chart-box">
+        <canvas id="continentChart"></canvas>
+      </div>
+
+      <div class="table-box">
+        <table id="continentTable">
+          <thead>
+          <tr>
+            <th class="rank">순위</th>
+            <th>대륙명</th>
+            <th th:text="${condition.continentMetric.label}">지표</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr th:each="row, stat : ${page.continentRankings}"
+              th:attr="data-label=${row.continentName}, data-value=${row.metricValueOrZero}">
+            <td class="rank" th:text="${stat.count}">1</td>
+            <td th:text="${row.continentName}">대륙명</td>
+            <td th:text="${#numbers.formatInteger(row.metricValueOrZero, 1, 'COMMA')}">0</td>
+          </tr>
+          <tr th:if="${#lists.isEmpty(page.continentRankings)}">
+            <td colspan="3" class="empty">조회된 대륙 통계가 없습니다.</td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="section-title">선택 대륙 강좌 순위</div>
+    <div class="sub-info"
+         th:text="'선택 대륙: ' + (${page.selectedContinentName != null} ? ${page.selectedContinentName} : '-') + ' / 기준: ' + ${condition.courseMetric.label}">
+      선택 대륙 정보
+    </div>
+
+    <div class="grid">
+      <div class="chart-box">
+        <canvas id="courseChart"></canvas>
+      </div>
+
+      <div class="table-box">
+        <table id="courseTable">
+          <thead>
+          <tr>
+            <th class="rank">순위</th>
+            <th>강좌명</th>
+            <th>강사명</th>
+            <th th:text="${condition.courseMetric.label}">지표</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr th:each="row, stat : ${page.courseRankings}"
+              th:attr="data-label=${row.courseTitle}, data-value=${row.metricValueOrZero}">
+            <td class="rank" th:text="${stat.count}">1</td>
+            <td th:text="${row.courseTitle}">강좌명</td>
+            <td th:text="${row.instructorName}">강사명</td>
+            <td th:text="${#numbers.formatInteger(row.metricValueOrZero, 1, 'COMMA')}">0</td>
+          </tr>
+          <tr th:if="${#lists.isEmpty(page.courseRankings)}">
+            <td colspan="4" class="empty">선택한 대륙의 강좌 통계가 없습니다.</td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  function extractChartData(tableId) {
+    const rows = document.querySelectorAll(`#${tableId} tbody tr[data-label]`);
+    const labels = [];
+    const values = [];
+
+    rows.forEach(row => {
+      labels.push(row.dataset.label);
+      values.push(Number(row.dataset.value || 0));
+    });
+
+    return { labels, values };
+  }
+
+  function renderBarChart(canvasId, labels, values, labelText) {
+    if (!labels.length) {
+      return;
+    }
+
+    new Chart(document.getElementById(canvasId), {
+      type: 'bar',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: labelText,
+          data: values,
+          borderWidth: 1
+        }]
+      },
+      options: {
+        responsive: true,
+        plugins: {
+          legend: {
+            display: true
+          }
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            ticks: {
+              precision: 0
+            }
+          }
+        }
+      }
+    });
+  }
+
+  const continentData = extractChartData('continentTable');
+  renderBarChart('continentChart', continentData.labels, continentData.values, '대륙 활성화 지표');
+
+  const courseData = extractChartData('courseTable');
+  renderBarChart('courseChart', courseData.labels, courseData.values, '강좌 순위 지표');
+</script>
+</body>
+</html></title>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
## 관련 이슈
Closes #이슈번호

## 작업 브랜치
feat/admin-view-chart

## 작업 목적
관리자 통계 페이지 구현

## 변경 사항(추가)
admin/dto/AdminContinentStatisticMetric.java
admin/dto/AdminCourseStatisticMetric.java
admin/dto/AdminStatisticsSearchCondition.java
admin/dto/AdminContinentOptionResponse.java
admin/dto/AdminContinentRankingResponse.java
admin/dto/AdminCourseRankingResponse.java
admin/dto/AdminStatisticsPageResponse.java
admin/repository/AdminStatisticsQueryRepository.java
admin/service/AdminStatisticsService.java
admin/controller/AdminStatisticsController.java

### 상세 변경 내용
1. admin-home에서 statistics url을 statics로 수정

## 테스트 내용
- [ ] 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] 로컬 실행 확인

