### PR TITLE
#134, 141 상세보기 버튼 삭제, 대륙게시판 TOP 문구 수정

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/continent/controller/ContinentController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/continent/controller/ContinentController.java
@@ -42,7 +42,7 @@ public class ContinentController {
 
         List<PostDTO> posts = postService.findPostsByContinent(continentId);
 
-        model.addAttribute("posts", posts.stream().limit(10).toList());
+        model.addAttribute("posts", posts.stream().limit(3).toList());
 
         model.addAttribute("continent", continent);
         model.addAttribute("courses" , courses);

--- a/src/main/resources/templates/continent/detail.html
+++ b/src/main/resources/templates/continent/detail.html
@@ -162,7 +162,6 @@
                 </div>
                 <div>
                     <a class="btn" th:href="@{/courses/{courseId}(courseId=${course.courseId})}">강좌 세부</a>
-
                 </div>
             </div>
         </div>
@@ -171,7 +170,7 @@
 
     <section class="section">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-            <h2 style="margin: 0;">대륙 게시판 TOP 10</h2>
+            <h2 style="margin: 0;">대륙 게시판 최신 TOP 3</h2>
             <a th:href="@{/continents/{id}/posts(id=${continent.continentId})}" class="btn" style="background: #1d295f; border: 1px solid #5f7cff;">
                 전체 게시판 이동 →
             </a>
@@ -184,10 +183,7 @@
                         <span class="notice-badge" th:if="${post.title.contains('[공지]')}">공지</span>
                         <a th:href="@{/posts/{id}(id=${post.postId})}" style="color: #7ee0ff; text-decoration: none;" th:text="${post.title}">게시글 제목</a>
                     </h3>
-                    <p>작성자 : <span th:text="${post.memberId}">작성자명</span></p>
-                </div>
-                <div>
-                    <a th:href="@{/posts/{id}(id=${post.postId})}" class="btn secondary">상세보기</a>
+                    <p>작성자 : <span th:text="${post.authorName}">작성자명</span></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## 관련 이슈
Closes #134 , #141 

## 작업 브랜치
- ex) feat/community-0416

## 작업 목적
- 사용자 입장에서 더 편리한 화면을 위해 상세보기 버튼 삭제, 대륙게시판 TOP 문구 수정

## 변경 사항
- contitnent controller 숫자 10을 3으로
- continent detail html

### 상세 변경 내용
1. 대륙 게시판에서 게시판 TOP 10 을 TOP 3으로 수정
2. 상세보기 버튼 없이 게시글 제목을 누르면 내용을 조회할 수 있도록 수정

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

