### PR TITLE
feat:관리자게시판&댓글&qa 삭제 기능구현

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminReportController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/controller/AdminReportController.java
@@ -5,7 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /*관리자 신고 목록 페이지 요청을 처리한다.
 * -> AdminReportService*/
@@ -16,9 +19,27 @@ public class AdminReportController {
 
     private final AdminReportService adminReportService;
 
+    //신고 목록 페이지 조회
     @GetMapping
     public String reportList(Model model) {
         model.addAttribute("reports", adminReportService.getReports());
         return "admin/report-list";
     }
+
+    //신고 상세 페이지 조회
+    @GetMapping("/{reportId}")
+    public String reportDetail(@PathVariable long reportId, Model model) {
+        model.addAttribute("report",adminReportService.getReportDetail(reportId));
+        return "admin/report-detail";
+    }
+
+    //신고 대상 삭제 처리
+    @PostMapping("/{reportId}/delete")
+    public String deleteReport(@PathVariable long reportId,
+                               RedirectAttributes redirectAttributes) {
+        adminReportService.deleteReportedTarget(reportId);
+        redirectAttributes.addFlashAttribute("message","신고 대상 삭제가 완료되었습니다.");
+        return "redirect:/admin/reports";
+    }
+
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminReportDetailResponse.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/dto/AdminReportDetailResponse.java
@@ -1,0 +1,117 @@
+package com.wanted.ailienlmsprogram.admin.dto;
+
+import com.wanted.ailienlmsprogram.community.entity.TargetType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AdminReportDetailResponse {
+
+    private Long reportId;
+    private TargetType targetType;
+    private String reportReason;
+    private LocalDateTime reportedAt;
+
+    private String reporterLoginId;
+    private String reporterName;
+
+    private Long targetMemberId;
+    private String targetMemberLoginId;
+    private String targetMemberName;
+
+    /**
+     * 게시글/댓글이면 "대륙", Q&A면 "강좌" 식으로 라벨을 분기하기 위한 값
+     */
+    private String categoryLabel;
+
+    /**
+     * 게시글/댓글이면 대륙명, Q&A면 강좌명
+     */
+    private String categoryValue;
+
+    /**
+     * 게시글/Q&A는 제목, 댓글은 "댓글"
+     */
+    private String targetTitle;
+
+    /**
+     * 실제 본문/댓글 내용/Q&A 본문
+     */
+    private String targetContent;
+
+    /**
+     * 댓글이면 원문 게시글 제목, Q&A 답변이면 부모 질문 제목
+     */
+    private String parentTitle;
+
+    private boolean targetDeleted;
+
+    public boolean hasTargetMember() {
+        return targetMemberId != null;
+    }
+
+    public boolean hasParentTitle() {
+        return !isBlank(parentTitle);
+    }
+
+    public boolean canDelete() {
+        return !targetDeleted;
+    }
+
+    public String getTargetTypeLabel() {
+        return switch (targetType) {
+            case CONTINENT_POST -> "게시글 신고";
+            case CONTINENT_COMMENT -> "댓글 신고";
+            case QNA -> "Q&A 신고";
+        };
+    }
+
+    public String getTargetStatusLabel() {
+        return targetDeleted ? "삭제/비공개" : "정상";
+    }
+
+    public String getDisplayReporterLoginId() {
+        return isBlank(reporterLoginId) ? "-" : reporterLoginId;
+    }
+
+    public String getDisplayReporterName() {
+        return isBlank(reporterName) ? "-" : reporterName;
+    }
+
+    public String getDisplayTargetMemberLoginId() {
+        return isBlank(targetMemberLoginId) ? "-" : targetMemberLoginId;
+    }
+
+    public String getDisplayTargetMemberName() {
+        return isBlank(targetMemberName) ? "-" : targetMemberName;
+    }
+
+    public String getDisplayCategoryLabel() {
+        return isBlank(categoryLabel) ? "분류" : categoryLabel;
+    }
+
+    public String getDisplayCategoryValue() {
+        return isBlank(categoryValue) ? "-" : categoryValue;
+    }
+
+    public String getDisplayTargetTitle() {
+        return isBlank(targetTitle) ? "삭제되었거나 존재하지 않는 대상" : targetTitle;
+    }
+
+    public String getDisplayTargetContent() {
+        return isBlank(targetContent) ? "-" : targetContent;
+    }
+
+    public String getDisplayParentTitle() {
+        return isBlank(parentTitle) ? "-" : parentTitle;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminReportCommandRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminReportCommandRepository.java
@@ -1,0 +1,66 @@
+package com.wanted.ailienlmsprogram.admin.repository;
+
+import com.wanted.ailienlmsprogram.community.entity.CommunityComment;
+import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
+import com.wanted.ailienlmsprogram.community.entity.Report;
+import com.wanted.ailienlmsprogram.qna.entity.Qna;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class AdminReportCommandRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public void deleteReportedTarget(Long reportId) {
+        Report report = em.find(Report.class, reportId);
+
+        if (report == null) {
+            throw new IllegalArgumentException("존재하지 않는 신고입니다.");
+        }
+
+        switch (report.getTargetType()) {
+            case CONTINENT_POST -> deletePost(report.getTargetNo());
+            case CONTINENT_COMMENT -> deleteComment(report.getTargetNo());
+            case QNA -> deleteQna(report.getTargetNo());
+        }
+    }
+
+    private void deletePost(Long postId) {
+        CommunityPost post = em.find(CommunityPost.class, postId);
+
+        if (post == null) {
+            throw new IllegalArgumentException("삭제할 게시글이 존재하지 않습니다.");
+        }
+
+        if (!post.isPostIsDeleted()) {
+            post.setPostIsDeleted(true);
+        }
+    }
+
+    private void deleteComment(Long commentId) {
+        CommunityComment comment = em.find(CommunityComment.class, commentId);
+
+        if (comment == null) {
+            throw new IllegalArgumentException("삭제할 댓글이 존재하지 않습니다.");
+        }
+
+        if (!comment.isDeleted()) {
+            comment.delete();
+        }
+    }
+
+    private void deleteQna(Long qnaId) {
+        Qna qna = em.find(Qna.class, qnaId);
+
+        if (qna == null) {
+            throw new IllegalArgumentException("삭제할 Q&A가 존재하지 않습니다.");
+        }
+
+        if (!qna.isQnaIsDeleted()) {
+            qna.delete();
+        }
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminReportQueryRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminReportQueryRepository.java
@@ -1,5 +1,6 @@
 package com.wanted.ailienlmsprogram.admin.repository;
 
+import com.wanted.ailienlmsprogram.admin.dto.AdminReportDetailResponse;
 import com.wanted.ailienlmsprogram.admin.dto.AdminReportListResponse;
 import com.wanted.ailienlmsprogram.community.entity.CommunityComment;
 import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
@@ -7,29 +8,24 @@ import com.wanted.ailienlmsprogram.community.entity.Report;
 import com.wanted.ailienlmsprogram.community.entity.TargetType;
 import com.wanted.ailienlmsprogram.continent.entity.Continent;
 import com.wanted.ailienlmsprogram.member.entity.Member;
+import com.wanted.ailienlmsprogram.qna.entity.Qna;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/*관리자 신고 목록 화면에 필요한 조회 전용 리포지토리
-*
-* - 신고 엔티티를 기준으로 신고자, 게시글, 댓글, 대륙 정보를 수집한 뒤
-* - 관리자 화면에 바로 출력할 수 있는 DTO로 가공한다.*/
+/*
+ * 관리자 신고 목록/상세 화면에 필요한 조회 전용 리포지토리
+ */
 @Repository
 public class AdminReportQueryRepository {
 
     @PersistenceContext
     private EntityManager em;
 
-    // 현재 신고 목록을 조회한다.
     public List<AdminReportListResponse> findReports() {
         List<Report> reports = em.createQuery("""
                 select r
@@ -44,41 +40,62 @@ public class AdminReportQueryRepository {
 
         Set<Long> reporterIds = reports.stream()
                 .map(Report::getReporterNo)
-                .filter(id -> id != null)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
         Set<Long> postIds = reports.stream()
                 .filter(report -> report.getTargetType() == TargetType.CONTINENT_POST)
                 .map(Report::getTargetNo)
-                .filter(id -> id != null)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
         Set<Long> commentIds = reports.stream()
                 .filter(report -> report.getTargetType() == TargetType.CONTINENT_COMMENT)
                 .map(Report::getTargetNo)
-                .filter(id -> id != null)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        Set<Long> qnaIds = reports.stream()
+                .filter(report -> report.getTargetType() == TargetType.QNA)
+                .map(Report::getTargetNo)
+                .filter(Objects::nonNull)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
         Map<Long, Member> reporterMap = findMembers(reporterIds);
         Map<Long, CommunityPost> postMap = findPosts(postIds);
         Map<Long, CommunityComment> commentMap = findComments(commentIds);
+        Map<Long, Qna> qnaMap = findQnas(qnaIds);
         Map<Long, Continent> continentMap = findContinents(postMap, commentMap);
 
         return reports.stream()
-                .map(report -> toResponse(report, reporterMap, postMap, commentMap, continentMap))
+                .map(report -> toResponse(report, reporterMap, postMap, commentMap, qnaMap, continentMap))
                 .toList();
     }
 
-    //단일 신고 엔티티를 관리자 화면을 DTO로 변환한다.
-    private AdminReportListResponse toResponse(
-            Report report,
-            Map<Long, Member> reporterMap,
-            Map<Long, CommunityPost> postMap,
-            Map<Long, CommunityComment> commentMap,
-            Map<Long, Continent> continentMap
-    ) {
+    public AdminReportDetailResponse findReportDetail(Long reportId) {
+        Report report = em.find(Report.class, reportId);
+
+        if (report == null) {
+            throw new IllegalArgumentException("존재하지 않는 신고입니다.");
+        }
+
+        Member reporter = report.getReporterNo() != null ? em.find(Member.class, report.getReporterNo()) : null;
+
+        return switch (report.getTargetType()) {
+            case CONTINENT_POST -> buildPostDetail(report, reporter);
+            case CONTINENT_COMMENT -> buildCommentDetail(report, reporter);
+            case QNA -> buildQnaDetail(report, reporter);
+        };
+    }
+
+    private AdminReportListResponse toResponse(Report report,
+                                               Map<Long, Member> reporterMap,
+                                               Map<Long, CommunityPost> postMap,
+                                               Map<Long, CommunityComment> commentMap,
+                                               Map<Long, Qna> qnaMap,
+                                               Map<Long, Continent> continentMap) {
         Member reporter = reporterMap.get(report.getReporterNo());
-        TargetInfo targetInfo = resolveTargetInfo(report, postMap, commentMap, continentMap);
+        TargetInfo targetInfo = resolveTargetInfo(report, postMap, commentMap, qnaMap, continentMap);
 
         return new AdminReportListResponse(
                 report.getReportNo(),
@@ -90,20 +107,18 @@ public class AdminReportQueryRepository {
                 targetInfo.targetMemberId,
                 targetInfo.targetMemberLoginId,
                 targetInfo.targetMemberName,
-                targetInfo.continentName,
+                targetInfo.locationName,
                 targetInfo.targetTitle,
                 targetInfo.targetPreview,
                 targetInfo.targetDeleted
         );
     }
 
-    // 신고 대상 타입에 따라 대상 정보 해석 로직을 분기한다.
-    private TargetInfo resolveTargetInfo(
-            Report report,
-            Map<Long, CommunityPost> postMap,
-            Map<Long, CommunityComment> commentMap,
-            Map<Long, Continent> continentMap
-    ) {
+    private TargetInfo resolveTargetInfo(Report report,
+                                         Map<Long, CommunityPost> postMap,
+                                         Map<Long, CommunityComment> commentMap,
+                                         Map<Long, Qna> qnaMap,
+                                         Map<Long, Continent> continentMap) {
         if (report.getTargetType() == TargetType.CONTINENT_POST) {
             return buildPostTargetInfo(postMap.get(report.getTargetNo()), continentMap);
         }
@@ -112,10 +127,9 @@ public class AdminReportQueryRepository {
             return buildCommentTargetInfo(commentMap.get(report.getTargetNo()), continentMap);
         }
 
-        return buildQnaPlaceholderInfo();
+        return buildQnaTargetInfo(qnaMap.get(report.getTargetNo()));
     }
 
-    //게시글 신고 대상 정보를 생성한다.
     private TargetInfo buildPostTargetInfo(CommunityPost post, Map<Long, Continent> continentMap) {
         if (post == null) {
             return TargetInfo.missing();
@@ -135,7 +149,6 @@ public class AdminReportQueryRepository {
         );
     }
 
-    // 댓글 신고 대상 정보를 생성한다.
     private TargetInfo buildCommentTargetInfo(CommunityComment comment, Map<Long, Continent> continentMap) {
         if (comment == null) {
             return TargetInfo.missing();
@@ -143,7 +156,6 @@ public class AdminReportQueryRepository {
 
         Member targetMember = comment.getMember();
         CommunityPost parentPost = comment.getPost();
-
         Long continentId = parentPost != null ? parentPost.getContinentId() : null;
         Continent continent = continentId != null ? continentMap.get(continentId) : null;
 
@@ -152,26 +164,141 @@ public class AdminReportQueryRepository {
                 targetMember != null ? targetMember.getLoginId() : null,
                 targetMember != null ? targetMember.getName() : null,
                 continent != null ? continent.getContinentName() : null,
-                parentPost != null ? parentPost.getPostTitle() : "원문 게시글 없음",
+                parentPost != null ? parentPost.getPostTitle() : "댓글",
                 abbreviate(comment.getContent(), 90),
                 comment.isDeleted()
         );
     }
 
-    //Q&A 신고용 임시 대상 정보를 생성한다.
-    private TargetInfo buildQnaPlaceholderInfo() {
+    private TargetInfo buildQnaTargetInfo(Qna qna) {
+        if (qna == null) {
+            return TargetInfo.missing();
+        }
+
+        Member targetMember = qna.getAuthor();
+        String courseTitle = qna.getCourse() != null ? qna.getCourse().getCourseTitle() : null;
+
         return new TargetInfo(
-                null,
-                null,
-                null,
-                null,
-                "Q&A 신고",
-                "현재 관리 페이지는 community 신고(post/comment) 기준으로 우선 연결했습니다.",
-                false
+                targetMember != null ? targetMember.getMemberId() : null,
+                targetMember != null ? targetMember.getLoginId() : null,
+                targetMember != null ? targetMember.getName() : null,
+                courseTitle,
+                qna.getQnaTitle(),
+                abbreviate(qna.getQnaContent(), 90),
+                qna.isQnaIsDeleted()
         );
     }
 
-    // 신고자 회원 정보를 ID 집합으로 일괄 조회한다.
+    private AdminReportDetailResponse buildPostDetail(Report report, Member reporter) {
+        CommunityPost post = findPost(report.getTargetNo());
+
+        if (post == null) {
+            return missingDetail(report, reporter, "게시글");
+        }
+
+        Member targetMember = post.getMember();
+        Continent continent = post.getContinentId() != null ? em.find(Continent.class, post.getContinentId()) : null;
+
+        return AdminReportDetailResponse.builder()
+                .reportId(report.getReportNo())
+                .targetType(report.getTargetType())
+                .reportReason(report.getReason())
+                .reportedAt(report.getReportDate())
+                .reporterLoginId(reporter != null ? reporter.getLoginId() : null)
+                .reporterName(reporter != null ? reporter.getName() : null)
+                .targetMemberId(targetMember != null ? targetMember.getMemberId() : null)
+                .targetMemberLoginId(targetMember != null ? targetMember.getLoginId() : null)
+                .targetMemberName(targetMember != null ? targetMember.getName() : null)
+                .categoryLabel("대륙")
+                .categoryValue(continent != null ? continent.getContinentName() : null)
+                .targetTitle(post.getPostTitle())
+                .targetContent(post.getPostContent())
+                .parentTitle(null)
+                .targetDeleted(post.isPostIsDeleted())
+                .build();
+    }
+
+    private AdminReportDetailResponse buildCommentDetail(Report report, Member reporter) {
+        CommunityComment comment = findComment(report.getTargetNo());
+
+        if (comment == null) {
+            return missingDetail(report, reporter, "댓글");
+        }
+
+        Member targetMember = comment.getMember();
+        CommunityPost parentPost = comment.getPost();
+        Long continentId = parentPost != null ? parentPost.getContinentId() : null;
+        Continent continent = continentId != null ? em.find(Continent.class, continentId) : null;
+
+        return AdminReportDetailResponse.builder()
+                .reportId(report.getReportNo())
+                .targetType(report.getTargetType())
+                .reportReason(report.getReason())
+                .reportedAt(report.getReportDate())
+                .reporterLoginId(reporter != null ? reporter.getLoginId() : null)
+                .reporterName(reporter != null ? reporter.getName() : null)
+                .targetMemberId(targetMember != null ? targetMember.getMemberId() : null)
+                .targetMemberLoginId(targetMember != null ? targetMember.getLoginId() : null)
+                .targetMemberName(targetMember != null ? targetMember.getName() : null)
+                .categoryLabel("대륙")
+                .categoryValue(continent != null ? continent.getContinentName() : null)
+                .targetTitle("댓글")
+                .targetContent(comment.getContent())
+                .parentTitle(parentPost != null ? parentPost.getPostTitle() : null)
+                .targetDeleted(comment.isDeleted())
+                .build();
+    }
+
+    private AdminReportDetailResponse buildQnaDetail(Report report, Member reporter) {
+        Qna qna = findQna(report.getTargetNo());
+
+        if (qna == null) {
+            return missingDetail(report, reporter, "Q&A");
+        }
+
+        Member targetMember = qna.getAuthor();
+        String courseTitle = qna.getCourse() != null ? qna.getCourse().getCourseTitle() : null;
+        String parentTitle = qna.getParent() != null ? qna.getParent().getQnaTitle() : null;
+
+        return AdminReportDetailResponse.builder()
+                .reportId(report.getReportNo())
+                .targetType(report.getTargetType())
+                .reportReason(report.getReason())
+                .reportedAt(report.getReportDate())
+                .reporterLoginId(reporter != null ? reporter.getLoginId() : null)
+                .reporterName(reporter != null ? reporter.getName() : null)
+                .targetMemberId(targetMember != null ? targetMember.getMemberId() : null)
+                .targetMemberLoginId(targetMember != null ? targetMember.getLoginId() : null)
+                .targetMemberName(targetMember != null ? targetMember.getName() : null)
+                .categoryLabel("강좌")
+                .categoryValue(courseTitle)
+                .targetTitle(qna.getQnaTitle())
+                .targetContent(qna.getQnaContent())
+                .parentTitle(parentTitle)
+                .targetDeleted(qna.isQnaIsDeleted())
+                .build();
+    }
+
+    private AdminReportDetailResponse missingDetail(Report report, Member reporter, String targetLabel) {
+        return AdminReportDetailResponse.builder()
+                .reportId(report.getReportNo())
+                .targetType(report.getTargetType())
+                .reportReason(report.getReason())
+                .reportedAt(report.getReportDate())
+                .reporterLoginId(reporter != null ? reporter.getLoginId() : null)
+                .reporterName(reporter != null ? reporter.getName() : null)
+                .targetMemberId(null)
+                .targetMemberLoginId(null)
+                .targetMemberName(null)
+                .categoryLabel("분류")
+                .categoryValue(null)
+                .targetTitle(targetLabel + "이(가) 이미 삭제되었거나 존재하지 않습니다.")
+                .targetContent(null)
+                .parentTitle(null)
+                .targetDeleted(true)
+                .build();
+    }
+
     private Map<Long, Member> findMembers(Set<Long> memberIds) {
         if (memberIds.isEmpty()) {
             return Collections.emptyMap();
@@ -188,7 +315,6 @@ public class AdminReportQueryRepository {
                 .collect(Collectors.toMap(Member::getMemberId, Function.identity()));
     }
 
-    // 신고 대상 게시글 정보를 ID 집합으로 일괄 조회한다.
     private Map<Long, CommunityPost> findPosts(Set<Long> postIds) {
         if (postIds.isEmpty()) {
             return Collections.emptyMap();
@@ -206,7 +332,6 @@ public class AdminReportQueryRepository {
                 .collect(Collectors.toMap(CommunityPost::getPostId, Function.identity()));
     }
 
-    // 신고 대상 댓글 정보를 ID 집합으로 일괄 조회한다.
     private Map<Long, CommunityComment> findComments(Set<Long> commentIds) {
         if (commentIds.isEmpty()) {
             return Collections.emptyMap();
@@ -225,11 +350,27 @@ public class AdminReportQueryRepository {
                 .collect(Collectors.toMap(CommunityComment::getCommentId, Function.identity()));
     }
 
-    // 게시글/댓글로부터 연관 대륙 ID를 수집하여 대륙 정보를 일괄 조회한다.
-    private Map<Long, Continent> findContinents(
-            Map<Long, CommunityPost> postMap,
-            Map<Long, CommunityComment> commentMap
-    ) {
+    private Map<Long, Qna> findQnas(Set<Long> qnaIds) {
+        if (qnaIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return em.createQuery("""
+                select distinct q
+                from Qna q
+                left join fetch q.author
+                left join fetch q.course
+                left join fetch q.parent
+                where q.qnaId in :qnaIds
+                """, Qna.class)
+                .setParameter("qnaIds", qnaIds)
+                .getResultList()
+                .stream()
+                .collect(Collectors.toMap(Qna::getQnaId, Function.identity()));
+    }
+
+    private Map<Long, Continent> findContinents(Map<Long, CommunityPost> postMap,
+                                                Map<Long, CommunityComment> commentMap) {
         Set<Long> continentIds = new LinkedHashSet<>();
 
         for (CommunityPost post : postMap.values()) {
@@ -259,7 +400,48 @@ public class AdminReportQueryRepository {
                 .collect(Collectors.toMap(Continent::getContinentId, Function.identity()));
     }
 
-    // 긴 본문을 목록 화면에 맞게 잘라내어 미리보기 문자열로 변환한다.
+    private CommunityPost findPost(Long postId) {
+        List<CommunityPost> result = em.createQuery("""
+                select distinct p
+                from CommunityPost p
+                left join fetch p.member
+                where p.postId = :postId
+                """, CommunityPost.class)
+                .setParameter("postId", postId)
+                .getResultList();
+
+        return result.isEmpty() ? null : result.get(0);
+    }
+
+    private CommunityComment findComment(Long commentId) {
+        List<CommunityComment> result = em.createQuery("""
+                select distinct c
+                from CommunityComment c
+                left join fetch c.member
+                left join fetch c.post
+                where c.commentId = :commentId
+                """, CommunityComment.class)
+                .setParameter("commentId", commentId)
+                .getResultList();
+
+        return result.isEmpty() ? null : result.get(0);
+    }
+
+    private Qna findQna(Long qnaId) {
+        List<Qna> result = em.createQuery("""
+                select distinct q
+                from Qna q
+                left join fetch q.author
+                left join fetch q.course
+                left join fetch q.parent
+                where q.qnaId = :qnaId
+                """, Qna.class)
+                .setParameter("qnaId", qnaId)
+                .getResultList();
+
+        return result.isEmpty() ? null : result.get(0);
+    }
+
     private String abbreviate(String value, int maxLength) {
         if (value == null || value.isBlank()) {
             return null;
@@ -276,38 +458,31 @@ public class AdminReportQueryRepository {
         return normalized.substring(0, maxLength) + "...";
     }
 
-    /*신고 대상의 화면 표시용 벙보를 임시로 묶는 내부 클래스.
-    *
-    * - 대상 회원, 대륙, 제목, 미리보기, 삭제 여부를 함께 들고 다니며
-    * - 최종 AdminReportListResponse 조립에 사용된다.*/
     private static class TargetInfo {
         private final Long targetMemberId;
         private final String targetMemberLoginId;
         private final String targetMemberName;
-        private final String continentName;
+        private final String locationName;
         private final String targetTitle;
         private final String targetPreview;
         private final boolean targetDeleted;
 
-        private TargetInfo(
-                Long targetMemberId,
-                String targetMemberLoginId,
-                String targetMemberName,
-                String continentName,
-                String targetTitle,
-                String targetPreview,
-                boolean targetDeleted
-        ) {
+        private TargetInfo(Long targetMemberId,
+                           String targetMemberLoginId,
+                           String targetMemberName,
+                           String locationName,
+                           String targetTitle,
+                           String targetPreview,
+                           boolean targetDeleted) {
             this.targetMemberId = targetMemberId;
             this.targetMemberLoginId = targetMemberLoginId;
             this.targetMemberName = targetMemberName;
-            this.continentName = continentName;
+            this.locationName = locationName;
             this.targetTitle = targetTitle;
             this.targetPreview = targetPreview;
             this.targetDeleted = targetDeleted;
         }
 
-        // 대상이 이미 삭제되었거나 조회되지 않을 때 사용할 기본 정보를 생성한다.
         private static TargetInfo missing() {
             return new TargetInfo(
                     null,

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminReportService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminReportService.java
@@ -1,6 +1,8 @@
 package com.wanted.ailienlmsprogram.admin.service;
 
+import com.wanted.ailienlmsprogram.admin.dto.AdminReportDetailResponse;
 import com.wanted.ailienlmsprogram.admin.dto.AdminReportListResponse;
+import com.wanted.ailienlmsprogram.admin.repository.AdminReportCommandRepository;
 import com.wanted.ailienlmsprogram.admin.repository.AdminReportQueryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,8 +18,19 @@ import java.util.List;
 public class AdminReportService {
 
     private final AdminReportQueryRepository adminReportQueryRepository;
+    private final AdminReportCommandRepository adminReportCommandRepository;
+
 
     public List<AdminReportListResponse> getReports() {
         return adminReportQueryRepository.findReports();
+    }
+
+
+    public AdminReportDetailResponse getReportDetail(long reportId){
+        return adminReportQueryRepository.findReportDetail(reportId);}
+
+    @Transactional
+    public void deleteReportedTarget(Long reportId){
+        adminReportCommandRepository.deleteReportedTarget(reportId);
     }
 }

--- a/src/main/resources/templates/admin/report-detail.html
+++ b/src/main/resources/templates/admin/report-detail.html
@@ -1,0 +1,311 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>신고 상세 확인 | ADMIN</title>
+  <style>
+    :root {
+      --bg: #f6f8fb;
+      --card: #ffffff;
+      --text-main: #1f2937;
+      --secondary: #64748b;
+      --border: #e5e7eb;
+      --primary: #7c3aed;
+      --danger: #dc2626;
+      --danger-dark: #b91c1c;
+      --muted: #f8fafc;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text-main);
+    }
+
+    aside {
+      width: 240px;
+      background: #111827;
+      color: white;
+      position: fixed;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      padding: 24px 16px;
+    }
+
+    .sidebar-header {
+      font-size: 20px;
+      font-weight: 700;
+      margin-bottom: 24px;
+    }
+
+    .sidebar-menu {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .nav-item {
+      display: block;
+      padding: 12px 14px;
+      border-radius: 10px;
+      color: white;
+      text-decoration: none;
+      background: transparent;
+    }
+
+    .nav-item:hover,
+    .nav-item.active {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    main {
+      margin-left: 240px;
+      min-height: 100vh;
+    }
+
+    header {
+      background: white;
+      border-bottom: 1px solid var(--border);
+      padding: 20px 32px;
+    }
+
+    .breadcrumb {
+      color: var(--secondary);
+      font-size: 14px;
+    }
+
+    .container {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 32px;
+    }
+
+    .page-header {
+      margin-bottom: 24px;
+    }
+
+    .page-header h2 {
+      margin: 0 0 8px;
+    }
+
+    .page-description {
+      color: var(--secondary);
+    }
+
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 24px;
+      margin-bottom: 20px;
+      box-shadow: 0 6px 20px rgba(15, 23, 42, 0.04);
+    }
+
+    .detail-grid {
+      display: grid;
+      grid-template-columns: 180px 1fr;
+      gap: 14px 18px;
+    }
+
+    .label {
+      font-weight: 700;
+      color: var(--secondary);
+    }
+
+    .value {
+      color: var(--text-main);
+      word-break: break-word;
+    }
+
+    .content-box {
+      margin-top: 10px;
+      padding: 18px;
+      border-radius: 12px;
+      background: var(--muted);
+      border: 1px solid var(--border);
+      white-space: pre-wrap;
+      line-height: 1.6;
+    }
+
+    .status-badge {
+      display: inline-block;
+      padding: 8px 12px;
+      border-radius: 999px;
+      font-size: 13px;
+      font-weight: 700;
+    }
+
+    .status-active {
+      background: #dcfce7;
+      color: #166534;
+    }
+
+    .status-deleted {
+      background: #fee2e2;
+      color: #991b1b;
+    }
+
+    .action-bar {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      margin-top: 16px;
+    }
+
+    .btn {
+      display: inline-block;
+      padding: 12px 16px;
+      border-radius: 10px;
+      text-decoration: none;
+      border: none;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 700;
+    }
+
+    .btn-primary {
+      background: var(--primary);
+      color: white;
+    }
+
+    .btn-secondary {
+      background: #e5e7eb;
+      color: #111827;
+    }
+
+    .btn-danger {
+      background: var(--danger);
+      color: white;
+    }
+
+    .btn-danger:hover {
+      background: var(--danger-dark);
+    }
+
+    .disabled-text {
+      color: var(--secondary);
+      font-style: italic;
+    }
+  </style>
+</head>
+<body>
+
+<aside>
+  <div class="sidebar-header">ADMIN PANEL</div>
+  <nav class="sidebar-menu">
+    <a th:href="@{/admin}" class="nav-item">대시보드 홈</a>
+    <a th:href="@{/admin/members}" class="nav-item">회원/계정 관리</a>
+    <a th:href="@{/admin/instructors/new}" class="nav-item">강사 계정 생성</a>
+    <a th:href="@{/admin/reports}" class="nav-item active">게시판/신고 관리</a>
+    <a th:href="@{/admin/statics}" class="nav-item">통계/모니터링</a>
+    <a th:href="@{/admin/refunds}" class="nav-item">환불 요청 관리</a>
+    <a th:href="@{/admin/courses}" class="nav-item">강좌 신청 관리</a>
+    <a th:href="@{/admin/continent-notices}" class="nav-item">대륙 공지 작성</a>
+    <a th:href="@{/logout}" class="nav-item">로그아웃</a>
+  </nav>
+</aside>
+
+<main>
+  <header>
+    <div class="breadcrumb">
+      Admin &gt; 게시판/신고 관리 &gt;
+      <span style="color: var(--text-main); font-weight: 700;">신고 상세 확인</span>
+    </div>
+  </header>
+
+  <div class="container">
+    <div class="page-header">
+      <h2 th:text="${report.targetTypeLabel}">신고 상세</h2>
+      <div class="page-description">
+        신고 내용을 검토하고, 실제 컨텐츠를 확인한 뒤 관리자 권한으로 삭제할 수 있습니다.
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="detail-grid">
+        <div class="label">신고 번호</div>
+        <div class="value" th:text="${report.reportId}">1</div>
+
+        <div class="label">신고 일시</div>
+        <div class="value"
+             th:text="${#temporals.format(report.reportedAt, 'yyyy-MM-dd HH:mm')}">2026-04-19 22:00</div>
+
+        <div class="label">신고 유형</div>
+        <div class="value" th:text="${report.targetTypeLabel}">게시글 신고</div>
+
+        <div class="label">현재 상태</div>
+        <div class="value">
+                    <span class="status-badge"
+                          th:classappend="${report.targetDeleted} ? ' status-deleted' : ' status-active'"
+                          th:text="${report.targetStatusLabel}">
+                        정상
+                    </span>
+        </div>
+
+        <div class="label">신고 사유</div>
+        <div class="value" th:text="${report.reportReason}">신고 사유</div>
+
+        <div class="label">신고자</div>
+        <div class="value">
+          <span th:text="${report.displayReporterName}">이름</span>
+          (<span th:text="${report.displayReporterLoginId}">loginId</span>)
+        </div>
+
+        <div class="label">대상 작성자</div>
+        <div class="value">
+          <span th:text="${report.displayTargetMemberName}">이름</span>
+          (<span th:text="${report.displayTargetMemberLoginId}">loginId</span>)
+        </div>
+
+        <div class="label" th:text="${report.displayCategoryLabel}">대륙</div>
+        <div class="value" th:text="${report.displayCategoryValue}">값</div>
+
+        <div class="label">대상 제목</div>
+        <div class="value" th:text="${report.displayTargetTitle}">제목</div>
+
+        <div class="label" th:if="${report.hasParentTitle()}">상위 원문</div>
+        <div class="value" th:if="${report.hasParentTitle()}" th:text="${report.displayParentTitle}">
+          부모 제목
+        </div>
+      </div>
+
+      <div style="margin-top: 24px;">
+        <div class="label">대상 본문</div>
+        <div class="content-box" th:text="${report.displayTargetContent}">
+          실제 본문
+        </div>
+      </div>
+
+      <div class="action-bar">
+        <a th:href="@{/admin/reports}" class="btn btn-secondary">목록으로</a>
+
+        <a th:if="${report.hasTargetMember()}"
+           th:href="@{/admin/members(query=${report.targetMemberLoginId})}"
+           class="btn btn-primary">
+          계정 관리로 이동
+        </a>
+
+        <form th:if="${report.canDelete()}"
+              th:action="@{/admin/reports/{reportId}/delete(reportId=${report.reportId})}"
+              method="post"
+              style="display: inline;"
+              onsubmit="return confirm('정말 이 신고 대상을 삭제 처리하시겠습니까?');">
+          <button type="submit" class="btn btn-danger">관리자 삭제 처리</button>
+        </form>
+
+        <span th:unless="${report.canDelete()}" class="disabled-text">
+                    이미 삭제/비공개 처리된 대상입니다.
+                </span>
+      </div>
+    </div>
+  </div>
+</main>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin/report-list.html
+++ b/src/main/resources/templates/admin/report-list.html
@@ -317,6 +317,34 @@
             margin-bottom: 16px;
             opacity: 0.3;
         }
+        .alert-success {
+            margin: 16px 0 20px;
+            padding: 14px 18px;
+            border-radius: 12px;
+            background: #ecfdf5;
+            color: #065f46;
+            border: 1px solid #a7f3d0;
+            font-weight: 600;
+        }
+
+        .action-group {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            align-items: center;
+        }
+
+        .btn-primary {
+            background: var(--primary);
+            color: white;
+        }
+
+        .btn-primary:hover {
+            filter: brightness(0.95);
+        }
+
+
+
 
         /* --- Responsive --- */
         @media (max-width: 1024px) {
@@ -432,8 +460,9 @@
             <h2>커뮤니티 신고 내역</h2>
             <div class="page-description">
                 <i class="fa-solid fa-circle-info"></i>
-                게시글 및 댓글에 대한 신고 내역을 통합 조회합니다.
-                신고 사유를 검토한 후, <strong>계정 관리</strong> 버튼을 클릭하여 해당 사용자의 계정 상태를 즉시 조정할 수 있습니다.
+                게시글, 댓글, Q&A 신고 내역을 통합 조회합니다.
+                신고 사유를 검토한 뒤 <strong>상세 확인</strong>으로 실제 컨텐츠를 열어보고,
+                필요 시 관리자 권한으로 삭제 처리할 수 있습니다.
             </div>
         </div>
 
@@ -444,6 +473,11 @@
             </div>
         </div>
 
+        <div th:if="${message}" class="alert-success" th:text="${message}">
+            신고 대상 삭제가 완료되었습니다.
+        </div>
+
+
         <div class="table-card">
             <div class="table-wrap">
                 <table th:unless="${#lists.isEmpty(reports)}">
@@ -451,7 +485,7 @@
                     <tr>
                         <th>신고 일시</th>
                         <th>유형</th>
-                        <th>대륙</th>
+                        <th>대륙/강좌</th><
                         <th>대상 사용자</th>
                         <th>해당 컨텐츠</th>
                         <th>신고 사유</th>
@@ -502,12 +536,20 @@
                         </td>
 
                         <td style="text-align: center;">
-                            <a th:if="${report.hasTargetMember()}"
-                               th:href="@{/admin/members(query=${report.targetMemberLoginId})}"
-                               class="btn btn-secondary">
-                                <i class="fa-solid fa-user-gear"></i> 계정 관리
-                            </a>
-                            <span class="disabled-text" th:unless="${report.hasTargetMember()}">연결 불가</span>
+                            <div class="action-group">
+                                <a th:href="@{/admin/reports/{reportId}(reportId=${report.reportId})}"
+                                   class="btn btn-primary">
+                                    <i class="fa-solid fa-magnifying-glass"></i> 상세 확인
+                                </a>
+
+                                <a th:if="${report.hasTargetMember()}"
+                                   th:href="@{/admin/members(query=${report.targetMemberLoginId})}"
+                                   class="btn btn-secondary">
+                                    <i class="fa-solid fa-user-gear"></i> 계정 관리
+                                </a>
+
+                                <span class="disabled-text" th:unless="${report.hasTargetMember()}">연결 불가</span>
+                            </div>
                         </td>
                     </tr>
                     </tbody>


### PR DESCRIPTION
## 관련 이슈
Closes #156

## 작업 브랜치
- feat/admin-delete-post

## 작업 목적
관리자가 게시판,댓글, q&a 모두 solft delete가 가능하도록

## 변경 사항(추가)
- AdminReportDetailResponse
- AdminReportQueryRepository
- AdminReportController(수정)
- report-list 수정 및 report-detail 추가

### 상세 변경 내용
1.신고목록페이지
2.신고 상세보기 페이지
3.신고 대상 삭제하기

## 테스트 내용
- [ ] 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] 로컬 실행 확인

