### PR TITLE
fix: 관리자 강좌 상세보기 버그 해결

### DIFF
--- a/src/main/resources/templates/admin/course-list.html
+++ b/src/main/resources/templates/admin/course-list.html
@@ -601,7 +601,7 @@
                                   th:text="${course.statusLabel}">상태</span>
                         </td>
                         <td style="text-align: center;">
-                            <a th:href="@{|/admin/courses/${course.courseId}?query=${condition.query}&status=${condition.status}|}"
+                            <a th:href="@{/admin/courses/{courseId}(courseId=${course.courseId}, query=${condition.query}, status=${condition.status})}"
                                class="btn btn-secondary btn-sm">
                                 <i class="fa-solid fa-arrow-up-right-from-square"></i> 상세보기
                             </a>


### PR DESCRIPTION
## 관련 이슈
Closes #160

## 작업 브랜치
-refactor/admin-course-detail-bug

## 작업 목적
- 관리자 강좌상세보기 문제 해결

## 변경 사항
- admin/course-list.html

### 상세 변경 내용
기존: <a th:href="@{|/admin/courses/${course.courseId}?query=${condition.query}&status=${condition.status}|}">
수정: <a th:href="@{/admin/courses/{courseId}(courseId=${course.courseId}, query=${condition.query}, status=${condition.status})}">

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

