### PR TITLE
[학생] 수강 진척도 기능 구현

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/enrollment/entity/Enrollment.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/enrollment/entity/Enrollment.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
@@ -39,4 +40,11 @@ public class Enrollment {
 
     @Column(name = "created_at", nullable = false)
     private LocalDateTime enrolledAt;
+
+    @Column(name = "enrollment_progress_rate")
+    private BigDecimal enrollmentProgressRate;
+
+    public void updateProgressRate(BigDecimal rate) {
+        this.enrollmentProgressRate = rate;
+    }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/enrollment/service/EnrollmentService.java
@@ -11,6 +11,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -96,5 +97,12 @@ public class EnrollmentService {
                 .findByMember_LoginIdAndCourse_CourseId(loginId, courseId)
                 .map(Enrollment::getEnrollmentId)
                 .orElse(null);
+    }
+
+    public BigDecimal getProgressRate(String loginId, Long courseId) {
+        return enrollmentRepository
+                .findByMember_LoginIdAndCourse_CourseId(loginId, courseId)
+                .map(Enrollment::getEnrollmentProgressRate)
+                .orElse(BigDecimal.ZERO);
     }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/controller/LectureController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/controller/LectureController.java
@@ -7,7 +7,6 @@ import com.wanted.ailienlmsprogram.enrollment.service.EnrollmentService;
 import com.wanted.ailienlmsprogram.lecture.dto.LectureAddDTO;
 import com.wanted.ailienlmsprogram.lecture.dto.LectureFindDTO;
 import com.wanted.ailienlmsprogram.lecture.dto.LectureResponseDTO;
-import com.wanted.ailienlmsprogram.lecture.dto.LectureWatchDTO;
 import com.wanted.ailienlmsprogram.lecture.service.LectureService;
 import com.wanted.ailienlmsprogram.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.servlet.ModelAndView;
 
+import java.math.BigDecimal;
 import java.security.Principal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -62,6 +62,10 @@ public class LectureController {
             if (isEnrolled) {
                 // enrollmentId 가져오기 — EnrollmentService에 메서드 추가 필요
                 enrollmentId = enrollmentService.findEnrollmentId(principal.getName(), courseId);
+
+                // 진척도 가져오기
+                BigDecimal progressRate = enrollmentService.getProgressRate(principal.getName(), courseId);
+                model.addAttribute("progressRate", progressRate);
             }
         }
 
@@ -124,14 +128,4 @@ public class LectureController {
         return "redirect:/instructor/courses/" + courseId + "/lectures";
     }
 
-    @GetMapping("/student/lectures/{lectureId}")
-    public ModelAndView lectureWatch(ModelAndView mv, @PathVariable Long lectureId) {
-
-        LectureWatchDTO lecture = lectureService.findWatchLecture(lectureId);
-
-        mv.addObject("lecture" ,lecture);
-        mv.setViewName("lecture/watch");
-
-        return mv;
-    }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/controller/LectureProgressController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/controller/LectureProgressController.java
@@ -1,0 +1,49 @@
+package com.wanted.ailienlmsprogram.lectureprogress.controller;
+
+import com.wanted.ailienlmsprogram.global.security.CustomUserDetails;
+import com.wanted.ailienlmsprogram.lecture.dto.LectureWatchDTO;
+import com.wanted.ailienlmsprogram.lecture.service.LectureService;
+import com.wanted.ailienlmsprogram.lectureprogress.service.LectureProgressService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+@RequiredArgsConstructor
+public class LectureProgressController {
+
+    private final LectureProgressService lectureProgressService;
+    private final LectureService lectureService;
+
+    // 강의 시청 페이지
+    @GetMapping("/student/lectures/{lectureId}")
+    public ModelAndView lectureWatch(ModelAndView mv,
+                                     @PathVariable Long lectureId,
+                                     @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        LectureWatchDTO lecture = lectureService.findWatchLecture(lectureId);
+        boolean isCompleted = lectureProgressService.isCompleted(lectureId, userDetails.getMember().getMemberId());
+
+        mv.addObject("lecture", lecture);
+        mv.addObject("isCompleted", isCompleted);
+        mv.setViewName("lecture/watch");
+
+        return mv;
+    }
+
+    // 수강 완료 처리
+    @PostMapping("/student/lectures/{lectureId}/complete")
+    public String completeLecture(@PathVariable Long lectureId,
+                                  @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long memberId = userDetails.getMember().getMemberId();
+        lectureProgressService.completeLecture(lectureId, memberId);
+        Long courseId = lectureProgressService.findCourseId(lectureId);
+
+        return "redirect:/student/course/" + courseId;
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/dao/LectureProgressRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/dao/LectureProgressRepository.java
@@ -1,0 +1,15 @@
+package com.wanted.ailienlmsprogram.lectureprogress.dao;
+
+import com.wanted.ailienlmsprogram.lectureprogress.entity.LectureProgress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface LectureProgressRepository extends JpaRepository<LectureProgress, Long> {
+
+    // 해당 강의를 이미 완료했는지 확인
+    Optional<LectureProgress> findByMember_MemberIdAndLecture_LectureId(Long memberId, Long lectureId);
+
+    // 해당 강좌에서 완료된 강의 수 조회 (진척률 계산용)
+    int countByMember_MemberIdAndLecture_Course_CourseIdAndProgressIsCompletedTrue(Long memberId, Long courseId);
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/dto/LectureProgressDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/dto/LectureProgressDTO.java
@@ -1,0 +1,14 @@
+package com.wanted.ailienlmsprogram.lectureprogress.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class LectureProgressDTO {
+
+    private Long lectureId;
+
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/entity/LectureProgress.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/entity/LectureProgress.java
@@ -1,0 +1,44 @@
+package com.wanted.ailienlmsprogram.lectureprogress.entity;
+
+import com.wanted.ailienlmsprogram.lecture.entity.Lecture;
+import com.wanted.ailienlmsprogram.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Entity
+@Table(name = "lecture_progress")
+public class LectureProgress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "progress_id")
+    private Long progressId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id")
+    private Lecture lecture;
+
+    @Column(name = "progress_is_completed")
+    private Boolean progressIsCompleted;
+
+    public void complete() {
+        this.progressIsCompleted = true;
+    }
+
+    public static LectureProgress create(Member member, Lecture lecture) {
+        LectureProgress progress = new LectureProgress();
+        progress.member = member;
+        progress.lecture = lecture;
+        progress.progressIsCompleted = true;
+        return progress;
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/service/LectureProgressService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/service/LectureProgressService.java
@@ -1,0 +1,90 @@
+package com.wanted.ailienlmsprogram.lectureprogress.service;
+
+import com.wanted.ailienlmsprogram.enrollment.entity.Enrollment;
+import com.wanted.ailienlmsprogram.enrollment.repository.EnrollmentRepository;
+import com.wanted.ailienlmsprogram.lecture.dao.LectureRepository;
+import com.wanted.ailienlmsprogram.lecture.entity.Lecture;
+import com.wanted.ailienlmsprogram.lectureprogress.dao.LectureProgressRepository;
+import com.wanted.ailienlmsprogram.lectureprogress.entity.LectureProgress;
+import com.wanted.ailienlmsprogram.member.entity.Member;
+import com.wanted.ailienlmsprogram.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LectureProgressService {
+
+    private final LectureProgressRepository lectureProgressRepository;
+    private final LectureRepository lectureRepository;
+    private final MemberRepository memberRepository;
+    private final EnrollmentRepository enrollmentRepository;
+
+    // 수강 완료 처리
+    @Transactional
+    public void completeLecture(Long lectureId, Long memberId) {
+
+        // 1. 강의 조회
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다."));
+
+        // 2. 회원 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        // 3. 이미 완료된 강의면 중복 처리 방지
+        Optional<LectureProgress> existing = lectureProgressRepository
+                .findByMember_MemberIdAndLecture_LectureId(memberId, lectureId);
+
+        if (existing.isPresent() && existing.get().getProgressIsCompleted()) {
+            return;
+        }
+
+        // 4. LectureProgress 저장
+        LectureProgress progress = LectureProgress.create(member, lecture);
+        lectureProgressRepository.save(progress);
+
+        // 5. 진척률 계산
+        Long courseId = lecture.getCourse().getCourseId();
+
+        int totalLectures = lectureRepository.countByCourse_CourseId(courseId);
+        int completedLectures = lectureProgressRepository
+                .countByMember_MemberIdAndLecture_Course_CourseIdAndProgressIsCompletedTrue(memberId, courseId);
+
+        BigDecimal progressRate = BigDecimal.valueOf(completedLectures)
+                .divide(BigDecimal.valueOf(totalLectures), 2, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100));
+
+        // 6. Enrollment 진척률 업데이트
+        Enrollment enrollment = enrollmentRepository
+                .findByMemberMemberIdAndCourseCourseId(memberId, courseId)
+                .orElseThrow(() -> new IllegalArgumentException("수강 정보가 없습니다."));
+
+        enrollment.updateProgressRate(progressRate);
+
+        // 7. 진척률 100% 이면 등급 업그레이드
+        if (progressRate.compareTo(BigDecimal.valueOf(100)) == 0) {
+            member.upgradeRank();
+        }
+    }
+
+    // 수강 완료 여부 확인
+    public boolean isCompleted(Long lectureId, Long memberId) {
+        return lectureProgressRepository
+                .findByMember_MemberIdAndLecture_LectureId(memberId, lectureId)
+                .map(LectureProgress::getProgressIsCompleted)
+                .orElse(false);
+    }
+
+    // courseId 조회 (컨트롤러에서 redirect용으로 사용)
+    public Long findCourseId(Long lectureId) {
+        Lecture lecture = lectureRepository.findById(lectureId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다."));
+        return lecture.getCourse().getCourseId();
+    }
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/member/entity/Member.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/member/entity/Member.java
@@ -76,4 +76,12 @@ public class Member {
 
     @Column(name = "last_login_at")
     private LocalDateTime lastLoginAt;
+
+    public void upgradeRank() {
+        if (this.rank == MemberRank.NOVICE) {  // ← 서비스에 rank 필드 없음
+            this.rank = MemberRank.MINERVAL;
+        } else if (this.rank == MemberRank.MINERVAL) {
+            this.rank = MemberRank.REPTILIAN;
+        }
+    }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/member/service/MemberService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/member/service/MemberService.java
@@ -97,4 +97,6 @@ public class MemberService {
             member.setRank(Member.MemberRank.MINERVAL);
         }
     }
+
+
 }

--- a/src/main/resources/templates/course/detail.html
+++ b/src/main/resources/templates/course/detail.html
@@ -159,6 +159,17 @@
         <h3 style="margin-top: 0;">프로토콜 상태</h3>
 
         <div th:if="${isEnrolled}">
+          <!-- 진척도 바 -->
+          <div style="margin-bottom: 20px;">
+            <div style="display: flex; justify-content: space-between; font-size: 13px; color: #a9b6ec; margin-bottom: 8px;">
+              <span>수강 진척도</span>
+              <span th:text="${progressRate != null ? progressRate : 0} + '%'">0%</span>
+            </div>
+            <div style="background: #1e293b; border-radius: 999px; height: 8px; overflow: hidden;">
+              <div th:style="|width: ${progressRate != null ? progressRate : 0}%; background: linear-gradient(90deg, #5f7cff, #7ee0ff); height: 100%; border-radius: 999px; transition: width 0.5s;|"></div>
+            </div>
+          </div>
+
           <div class="price-tag" style="font-size: 24px;">침공 진행 중 🛸</div>
           <p style="color: #a9b6ec; font-size: 14px; line-height: 1.6; margin-bottom: 20px;">
             이미 승인된 프로토콜입니다.<br>커리큘럼을 통해 학습을 이어가세요.

--- a/src/main/resources/templates/lecture/watch.html
+++ b/src/main/resources/templates/lecture/watch.html
@@ -19,32 +19,14 @@
         .header {
             display: flex;
             align-items: center;
-            justify-content: space-between;
             padding: 16px 32px;
             background: #0d1117;
             border-bottom: 1px solid rgba(95, 124, 255, 0.15);
             position: sticky;
             top: 0;
             z-index: 100;
-        }
-
-        .header-left {
-            display: flex;
-            align-items: center;
             gap: 16px;
         }
-
-        .back-btn {
-            display: flex;
-            align-items: center;
-            gap: 6px;
-            color: #a9b6ec;
-            text-decoration: none;
-            font-size: 0.9rem;
-            transition: color 0.2s;
-        }
-
-        .back-btn:hover { color: #7ee0ff; }
 
         .lecture-title-header {
             font-size: 1rem;
@@ -79,7 +61,6 @@
             max-height: 600px;
         }
 
-        /* 영상 없을 때 */
         .no-video {
             display: flex;
             flex-direction: column;
@@ -107,7 +88,7 @@
             margin-bottom: 20px;
         }
 
-        /* ===== 완료 버튼 영역 ===== */
+        /* ===== 버튼 영역 ===== */
         .action-area {
             display: flex;
             justify-content: flex-end;
@@ -143,13 +124,13 @@
             opacity: 1;
         }
 
-        .btn-back {
-            background: rgba(95, 124, 255, 0.1);
-            color: #a9b6ec;
-            border: 1px solid rgba(95, 124, 255, 0.2);
+        .btn-exit {
+            background: rgba(239, 68, 68, 0.1);
+            color: #ef4444;
+            border: 1px solid rgba(239, 68, 68, 0.2);
         }
 
-        .btn-back:hover { background: rgba(95, 124, 255, 0.2); color: #f5f7ff; }
+        .btn-exit:hover { background: rgba(239, 68, 68, 0.2); }
 
         /* ===== 완료 상태 배지 ===== */
         .badge-completed {
@@ -181,6 +162,53 @@
             z-index: 10;
             white-space: nowrap;
         }
+
+        /* ===== 종료 확인 모달 ===== */
+        .modal-overlay {
+            display: none;
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.7);
+            z-index: 200;
+            justify-content: center;
+            align-items: center;
+            backdrop-filter: blur(4px);
+        }
+
+        .modal-overlay.active { display: flex; }
+
+        .modal-card {
+            background: #121a35;
+            border-radius: 16px;
+            padding: 40px;
+            border: 1px solid rgba(239, 68, 68, 0.2);
+            max-width: 400px;
+            width: 90%;
+            text-align: center;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+        }
+
+        .modal-icon { font-size: 2.5rem; margin-bottom: 16px; }
+
+        .modal-title {
+            font-size: 1.2rem;
+            font-weight: 700;
+            color: #f5f7ff;
+            margin-bottom: 8px;
+        }
+
+        .modal-desc {
+            font-size: 0.9rem;
+            color: #a9b6ec;
+            margin-bottom: 28px;
+            line-height: 1.6;
+        }
+
+        .modal-actions {
+            display: flex;
+            gap: 12px;
+            justify-content: center;
+        }
     </style>
 </head>
 
@@ -188,12 +216,7 @@
 
 <!-- ===== 헤더 ===== -->
 <header class="header">
-    <div class="header-left">
-        <a href="javascript:history.back();" class="back-btn">
-            ← 돌아가기
-        </a>
-        <span class="lecture-title-header" th:text="${lecture.lectureTitle}">강의 제목</span>
-    </div>
+    <span class="lecture-title-header" th:text="${lecture.lectureTitle}">강의 제목</span>
 </header>
 
 <!-- ===== MAIN ===== -->
@@ -201,11 +224,8 @@
 
     <!-- 영상 플레이어 -->
     <div class="video-container">
-
-        <!-- 건너뛰기 경고 -->
         <div class="skip-warning" id="skipWarning">⚠ 건너뛰기는 허용되지 않습니다</div>
 
-        <!-- 영상 있을 때 -->
         <video th:if="${lecture.videoUrl != null}"
                id="lectureVideo"
                controls
@@ -215,38 +235,70 @@
             브라우저가 video 태그를 지원하지 않습니다.
         </video>
 
-        <!-- 영상 없을 때 -->
         <div th:if="${lecture.videoUrl == null}" class="no-video">
             <p>등록된 영상이 없습니다.</p>
         </div>
-
     </div>
 
-    <!-- 강의 정보 + 완료 버튼 -->
+    <!-- 강의 정보 + 버튼 -->
     <div class="info-card">
         <h1 th:text="${lecture.lectureTitle}">강의 제목</h1>
         <div class="action-area">
 
-            <!-- 완료 버튼 (영상 끝까지 봐야 활성화, 진척도 기능 구현 후 연결 예정) -->
-            <button id="completeBtn"
-                    class="btn btn-complete"
-                    disabled
-                    onclick="completeLecture()">
-                수강 완료
-            </button>
+            <!-- 이미 완료된 경우 -->
+            <span th:if="${isCompleted}" class="badge-completed">✔ 수강 완료</span>
 
-            <a href="javascript:history.back();" class="btn btn-back">
-                목록으로
-            </a>
+            <!-- 수강 완료 버튼 — form POST 방식 (진척도 기능 연결 예정) -->
+            <form th:unless="${isCompleted}"
+                  th:action="@{/student/lectures/{lectureId}/complete(lectureId=${lecture.lectureId})}"
+                  method="post"
+                  id="completeForm">
+                <button type="submit"
+                        id="completeBtn"
+                        class="btn btn-complete"
+                        disabled>
+                    수강 완료
+                </button>
+            </form>
+
+            <!-- 종료 버튼 -->
+            <button type="button"
+                    class="btn btn-exit"
+                    onclick="openExitModal()">
+                종료
+            </button>
         </div>
     </div>
 
 </div>
 
+<!-- ===== 종료 확인 모달 ===== -->
+<div class="modal-overlay" id="exitModal">
+    <div class="modal-card">
+        <div class="modal-icon">🚀</div>
+        <p class="modal-title">강의를 종료하시겠습니까?</p>
+        <p class="modal-desc">
+            현재까지의 시청 위치가 저장됩니다.<br>
+            다음에 이어서 시청할 수 있습니다.
+        </p>
+        <div class="modal-actions">
+            <button type="button"
+                    class="btn btn-exit"
+                    onclick="confirmExit()">
+                예, 종료합니다
+            </button>
+            <button type="button"
+                    class="btn"
+                    style="background: rgba(95,124,255,0.1); color: #a9b6ec; border: 1px solid rgba(95,124,255,0.2);"
+                    onclick="closeExitModal()">
+                계속 시청
+            </button>
+        </div>
+    </div>
+</div>
+
 <script th:inline="javascript">
     const lectureId = /*[[${lecture.lectureId}]]*/ 0;
-    const csrfHeader = /*[[${_csrf?.headerName}]]*/ 'X-CSRF-TOKEN';
-    const csrfToken = /*[[${_csrf?.token}]]*/ '';
 
     const video = document.getElementById('lectureVideo');
     const completeBtn = document.getElementById('completeBtn');
@@ -255,7 +307,14 @@
     if (video) {
         let maxWatchedTime = 0;
 
-        // 건너뛰기 방지 — 최대 시청 위치보다 3초 이상 앞으로 가면 되돌림
+        // 이어보기 — 페이지 로드 시 저장된 위치로 이동
+        const savedPosition = localStorage.getItem('lecture_pos_' + lectureId);
+        if (savedPosition) {
+            video.currentTime = parseInt(savedPosition);
+            maxWatchedTime = parseInt(savedPosition);
+        }
+
+        // 건너뛰기 방지
         video.addEventListener('timeupdate', function () {
             if (video.currentTime > maxWatchedTime + 3) {
                 video.currentTime = maxWatchedTime;
@@ -266,38 +325,41 @@
             }
         });
 
+        // 30초마다 현재 위치 저장
+        setInterval(() => {
+            localStorage.setItem('lecture_pos_' + lectureId, Math.floor(video.currentTime));
+        }, 30000);
+
         // 영상 끝까지 재생 완료 시 수강 완료 버튼 활성화
         video.addEventListener('ended', function () {
             if (completeBtn) {
                 completeBtn.disabled = false;
+                localStorage.removeItem('lecture_pos_' + lectureId);
             }
         });
     }
 
-    // 수강 완료 처리 — POST /student/lectures/{lectureId}/complete
-    function completeLecture() {
-        if (completeBtn) completeBtn.disabled = true;
-
-        fetch('/student/lectures/' + lectureId + '/complete', {
-            method: 'POST',
-            headers: {
-                [csrfHeader]: csrfToken,
-                'Content-Type': 'application/json'
-            }
-        })
-        .then(response => {
-            if (response.ok) {
-                location.reload();  // 완료 처리 후 페이지 새로고침 → 수강 완료 배지 표시
-            } else {
-                alert('수강 완료 처리 중 오류가 발생했습니다.');
-                if (completeBtn) completeBtn.disabled = false;
-            }
-        })
-        .catch(() => {
-            alert('서버와 통신 중 오류가 발생했습니다.');
-            if (completeBtn) completeBtn.disabled = false;
-        });
+    // ===== 종료 모달 =====
+    function openExitModal() {
+        // 모달 열기 전 현재 위치 저장
+        if (video) {
+            localStorage.setItem('lecture_pos_' + lectureId, Math.floor(video.currentTime));
+        }
+        document.getElementById('exitModal').classList.add('active');
     }
+
+    function closeExitModal() {
+        document.getElementById('exitModal').classList.remove('active');
+    }
+
+    function confirmExit() {
+        history.back();
+    }
+
+    // 모달 바깥 클릭 시 닫기
+    document.getElementById('exitModal').addEventListener('click', function (e) {
+        if (e.target === this) closeExitModal();
+    });
 </script>
 
 </body>


### PR DESCRIPTION
## 관련 이슈
Closes #167 

## 작업 브랜치
- feat/lectureProgress

## 작업 목적
- 강좌 진척도 기능 구현

## 변경 사항
- lectureprogress 패키지
Entity / Repository / Service / Controller 신규 추가

- enrollment 패키지
Entity: enrollmentProgressRate 필드, updateProgressRate() 추가
Service: getProgressRate() 추가

- member 패키지
Entity: upgradeRank() 추가

- lecture 패키지
Service: findWatchLecture() 추가
Controller: viewMyLecture()에 progressRate 추가

### 상세 변경 내용
1 .강의 완료 처리 — 영상 끝까지 시청 후 수강 완료 버튼 클릭 시 LECTURE_PROGRESS 테이블에 완료 기록 저장
2. 진척률 계산 — 완료 강의 수 / 전체 강의 수 × 100, ENROLLMENT.enrollment_progress_rate 업데이트
3. 등급 업그레이드 — 진척률 100% 달성 시 MEMBER.member_rank 자동 승급 (NOVICE → MINERVAL → REPTILIAN)
4. 강좌 상세 페이지에 진척도 바 추가 — 수강 중인 학생에게만 표시

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

