### PR TITLE
feat:aspect-모든서비스가 실행될때 실행 시간이 찍힌다

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/global/aop/ServiceExecutionTimeAspect.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/global/aop/ServiceExecutionTimeAspect.java
@@ -1,0 +1,38 @@
+package com.wanted.ailienlmsprogram.global.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class ServiceExecutionTimeAspect {
+
+    @Around("execution(* com.wanted.ailienlmsprogram..service..*(..))")
+    public Object measureServiceExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        long start = System.currentTimeMillis();
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String className = signature.getDeclaringType().getSimpleName();
+        String methodName = signature.getName();
+
+        try {
+            Object result = joinPoint.proceed();
+
+            long end = System.currentTimeMillis();
+            System.out.println("[SERVICE TIME] " + className + "." + methodName
+                    + "() 실행 시간 = " + (end - start) + "ms");
+
+            return result;
+        } catch (Throwable e) {
+            long end = System.currentTimeMillis();
+            System.out.println("[SERVICE TIME] " + className + "." + methodName
+                    + "() 예외 발생, 실행 시간 = " + (end - start) + "ms");
+
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
Closes #175 

## 작업 브랜치
feat/timeAOP

## 작업 목적
- 모든 서비스 로직에 실행시간이 찍히는 로직을 적용(AOP)

## 변경 사항
global/aop/ServiceExecutionTimeAspect 추가

### 상세 변경 내용
```
package com.wanted.ailienlmsprogram.global.aop;

import org.aspectj.lang.ProceedingJoinPoint;
import org.aspectj.lang.annotation.Around;
import org.aspectj.lang.annotation.Aspect;
import org.aspectj.lang.reflect.MethodSignature;
import org.springframework.stereotype.Component;

@Aspect
@Component
public class ServiceExecutionTimeAspect {

    @Around("execution(* com.wanted.ailienlmsprogram..service..*(..))")
    public Object measureServiceExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {

        long start = System.currentTimeMillis();

        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
        String className = signature.getDeclaringType().getSimpleName();
        String methodName = signature.getName();

        try {
            Object result = joinPoint.proceed();

            long end = System.currentTimeMillis();
            System.out.println("[SERVICE TIME] " + className + "." + methodName
                    + "() 실행 시간 = " + (end - start) + "ms");

            return result;
        } catch (Throwable e) {
            long end = System.currentTimeMillis();
            System.out.println("[SERVICE TIME] " + className + "." + methodName
                    + "() 예외 발생, 실행 시간 = " + (end - start) + "ms");

            throw e;
        }
    }
}
```

## 테스트 내용
- [ ] 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] 로컬 실행 확인

