### PR TITLE
refund

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminRefundService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminRefundService.java
@@ -3,6 +3,7 @@ package com.wanted.ailienlmsprogram.admin.service;
 import com.wanted.ailienlmsprogram.admin.dto.AdminRefundListResponse;
 import com.wanted.ailienlmsprogram.coursecommand.entity.Course;
 import com.wanted.ailienlmsprogram.enrollment.service.EnrollmentService;
+import com.wanted.ailienlmsprogram.payment.client.TossPaymentClient;
 import com.wanted.ailienlmsprogram.payment.entity.Payment;
 import com.wanted.ailienlmsprogram.payment.entity.PaymentItem;
 import com.wanted.ailienlmsprogram.payment.entity.Refund;
@@ -26,6 +27,7 @@ public class AdminRefundService {
 
     private final RefundRepository refundRepository;
     private final EnrollmentService enrollmentService;
+    private final TossPaymentClient tossPaymentClient;
 
 
     public List<AdminRefundListResponse> getRefunds(Refund.RefundStatus status){
@@ -37,10 +39,10 @@ public class AdminRefundService {
                 .toList();
     }
     /**
-     * 서버사이드 결제의 REQUESTED 환불을 승인 처리한다.
-     * 수강 취소(REFUNDED)까지 한 트랜잭션에서 처리.
+     * REQUESTED 환불을 승인 처리한다.
+     * - Toss 결제: cancel API 호출 후 수강 취소
+     * - 서버사이드 결제: 수강 취소만 처리
      */
-    //환불 요청을 승인 처리한다
     @Transactional
     public void approveRefund(Long refundId) {
         Refund refund = refundRepository.findById(refundId)
@@ -50,11 +52,18 @@ public class AdminRefundService {
             throw new IllegalArgumentException("처리 대기 중(REQUESTED) 상태의 환불만 승인할 수 있습니다.");
         }
 
+        Payment payment = refund.getPayment();
+
+        // Toss 결제인 경우 결제 취소 API 호출 (실패 시 예외 → 트랜잭션 롤백)
+        String tossPaymentKey = payment.getTossPaymentKey();
+        if (tossPaymentKey != null && !tossPaymentKey.isBlank()) {
+            tossPaymentClient.cancel(tossPaymentKey, refund.getRefundReason());
+        }
+
         refund.setRefundStatus(Refund.RefundStatus.APPROVED);
         refund.setRefundProcessedAt(LocalDateTime.now());
 
         // 결제에 포함된 강좌 수강 취소
-        Payment payment = refund.getPayment();
         List<Course> courses = payment.getItems().stream()
                 .map(PaymentItem::getCourse)
                 .toList();

--- a/src/main/java/com/wanted/ailienlmsprogram/payment/service/PaymentService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/payment/service/PaymentService.java
@@ -1,6 +1,5 @@
 package com.wanted.ailienlmsprogram.payment.service;
 
-import com.wanted.ailienlmsprogram.coursecommand.entity.Course;
 import com.wanted.ailienlmsprogram.enrollment.service.EnrollmentService;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import com.wanted.ailienlmsprogram.payment.client.TossPaymentClient;
@@ -181,8 +180,7 @@ public class PaymentService {
 
     /**
      * 환불 요청.
-     * - Toss 결제: cancel API 호출 → APPROVED 저장 + 수강 취소
-     * - 서버사이드 결제: REQUESTED 저장 → 관리자 수동 승인 대기
+     * - 결제 수단에 관계없이 REQUESTED 상태로 저장 → 관리자 승인/거절 대기
      */
     @Transactional
     public void requestRefund(Long paymentId, String refundReason, Member member) {
@@ -199,24 +197,6 @@ public class PaymentService {
         refund.setRefundReason(refundReason);
         refund.setRefundStatus(Refund.RefundStatus.REQUESTED);
         refund.setRefundRequestedAt(LocalDateTime.now());
-
-        String tossPaymentKey = payment.getTossPaymentKey();
-
-        if (tossPaymentKey != null && !tossPaymentKey.isBlank()) {
-            // Toss cancel API 호출 (실패 시 예외 → 트랜잭션 롤백)
-            tossPaymentClient.cancel(tossPaymentKey, refundReason);
-            refund.setRefundStatus(Refund.RefundStatus.APPROVED);
-            refund.setRefundProcessedAt(LocalDateTime.now());
-
-            // 수강 취소
-            List<Course> courses = payment.getItems().stream()
-                    .map(PaymentItem::getCourse)
-                    .toList();
-            enrollmentService.unenroll(member, courses);
-        } else {
-            // 서버사이드 결제 → 관리자 수동 승인 대기
-            refund.setRefundStatus(Refund.RefundStatus.REQUESTED);
-        }
 
         refundRepository.save(refund);
     }


### PR DESCRIPTION
---

## 관련 이슈
Closes #179 

## 작업 브랜치
- `feat/payment-refund-process`

## 작업 목적
- 학생의 환불 신청 시 즉시 결제가 취소되는 기존 방식을 개선하여 관리자의 검토 및 승인을 거치는 **'승인 기반 환불 프로세스'** 도입
- Toss API 취소 시점과 내부 DB(수강 상태/환불 상태) 업데이트 시점을 일치시켜 데이터 무결성 보장

## 변경 사항
- **payment / admin** 패키지
- **PaymentService, AdminRefundService, TossPaymentClient**

### 상세 변경 내용
1. **환불 신청 로직 단일화 (`PaymentService`)**: Toss API 즉시 호출 분기를 삭제하고, 모든 환불 요청을 `REQUESTED` 상태로 DB에 저장하도록 수정
2. **관리자 승인 기능 고도화 (`AdminRefundService`)**: `TossPaymentClient`를 주입하여 승인 시점에 실제 결제 취소 API를 호출하고, 성공 시에만 수강권 회수 및 `REFUNDED` 상태 업데이트 수행
3. **환불 거절 프로세스 구현**: `rejectRefund()`를 통해 결제 취소 없이 상태값만 `REJECTED`로 변경하여 수강 권한 유지 로직 확립
4. **데이터 일관성 확보**: 외부 API 호출과 내부 DB 반영을 하나의 트랜잭션으로 관리하여 예외 발생 시 롤백 처리

## 테스트 내용
- [x] 정상 동작 확인: 학생 환불 신청 시 즉시 취소되지 않고 DB에 `REQUESTED` 상태로 기록되는지 확인
- [x] 정상 동작 확인: 관리자 승인 시 Toss API 취소 응답 수신 후 수강권 자동 회수 및 상태 변경 확인
- [x] 예외 케이스 확인: 관리자 거절 시 결제 유지 및 수강 권한 유지 확인
- [x] 예외 케이스 확인: API 호출 실패 시 DB 상태가 변경되지 않고 유지되는지 확인
- [x] 로컬 실행 확인: 로컬 환경에서 전체 환불 신청-승인-완료 플로우 테스트 완료