### PR TITLE
강좌 공지사항 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/coursenotice/controller/CourseNoticeController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursenotice/controller/CourseNoticeController.java
@@ -1,6 +1,7 @@
 package com.wanted.ailienlmsprogram.coursenotice.controller;
 
 import com.wanted.ailienlmsprogram.coursenotice.dto.CourseNoticeApplyDTO;
+import com.wanted.ailienlmsprogram.coursenotice.dto.CourseNoticeDetailDTO;
 import com.wanted.ailienlmsprogram.coursenotice.dto.CourseNoticeFindDTO;
 import com.wanted.ailienlmsprogram.coursenotice.service.CourseNoticeService;
 import com.wanted.ailienlmsprogram.global.security.CustomUserDetails;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -126,6 +128,17 @@ public class CourseNoticeController {
         mv.setViewName("student/notice-list");
 
         return mv;
+    }
+
+    // 공지 상세 조회
+    @GetMapping("/student/notice/{noticeId}")
+    public String findNoticeDetail(@PathVariable("noticeId") Long noticeId, Model model) {
+        CourseNoticeDetailDTO notice = courseNoticeService.detailNotice(noticeId);
+        model.addAttribute("notice", notice);
+
+        model.addAttribute("courseId", notice.getCourseID());
+
+        return "student/notice-detail";
     }
 }
 

--- a/src/main/java/com/wanted/ailienlmsprogram/coursenotice/dto/CourseNoticeDetailDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursenotice/dto/CourseNoticeDetailDTO.java
@@ -1,0 +1,24 @@
+package com.wanted.ailienlmsprogram.coursenotice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CourseNoticeDetailDTO {
+
+    private Long noticeId;
+    private Long courseID;
+    private String noticeTitle;
+    private String noticeContent;
+    private String authorName;      // author.getName() 으로 세팅
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/coursenotice/service/CourseNoticeService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursenotice/service/CourseNoticeService.java
@@ -4,6 +4,7 @@ import com.wanted.ailienlmsprogram.coursecommand.dao.CourseRepository;
 import com.wanted.ailienlmsprogram.coursecommand.entity.Course;
 import com.wanted.ailienlmsprogram.coursenotice.dao.CourseNoticeRepository;
 import com.wanted.ailienlmsprogram.coursenotice.dto.CourseNoticeApplyDTO;
+import com.wanted.ailienlmsprogram.coursenotice.dto.CourseNoticeDetailDTO;
 import com.wanted.ailienlmsprogram.coursenotice.dto.CourseNoticeFindDTO;
 import com.wanted.ailienlmsprogram.coursenotice.entity.CourseNotice;
 import com.wanted.ailienlmsprogram.enrollment.entity.Enrollment;
@@ -11,6 +12,7 @@ import com.wanted.ailienlmsprogram.enrollment.repository.EnrollmentRepository;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import com.wanted.ailienlmsprogram.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +29,7 @@ public class CourseNoticeService {
     private final CourseRepository courseRepository;
     private final MemberRepository memberRepository;
     private final EnrollmentRepository enrollmentRepository;
+    private final ModelMapper modelMapper;
 
     // ===== 조회 =====
 
@@ -132,6 +135,25 @@ public class CourseNoticeService {
 
         // 2. DB에서 삭제
         courseNoticeRepository.delete(notice);
+    }
+
+
+    public CourseNoticeDetailDTO detailNotice(Long noticeId) {
+
+        CourseNotice notice = courseNoticeRepository.findById(noticeId)
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 공지사항입니다."));
+
+        CourseNoticeDetailDTO detail = modelMapper.map(notice, CourseNoticeDetailDTO.class);
+
+        if (notice.getCourse() != null) {
+            detail.setCourseID(notice.getCourse().getCourseId());
+        }
+
+        if (notice.getAuthor() != null) {
+            detail.setAuthorName(notice.getAuthor().getName());
+        }
+
+        return detail;
     }
 }
 

--- a/src/main/resources/templates/student/notice-detail.html
+++ b/src/main/resources/templates/student/notice-detail.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html class="dark" lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>MISSION DETAIL | MODULE02 LMS</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;700&family=Inter:wght@400;500&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet"/>
+  <style>
+    body { font-family: 'Inter', sans-serif; background-color: #0b0e14; color: #ecedf6; }
+    .font-headline { font-family: 'Space Grotesk', sans-serif; }
+  </style>
+</head>
+<body class="min-h-screen pt-24 px-6 md:px-12 pb-12 max-w-4xl mx-auto">
+
+<div class="mb-10">
+  <a th:href="@{/student/courses/{id}/notices(id=${courseId})}"
+     class="flex items-center gap-1 text-slate-500 hover:text-cyan-400 transition-colors text-xs font-headline mb-4">
+    <span class="material-symbols-outlined text-sm">arrow_back</span> BACK TO BRIEFING LIST
+  </a>
+  <h1 class="text-4xl font-headline font-bold text-on-surface tracking-tighter mb-2">MISSION DETAIL</h1>
+</div>
+
+<div class="bg-slate-900/40 backdrop-blur-xl rounded-3xl border border-slate-800 p-10 shadow-2xl">
+  <div class="flex justify-between items-start mb-8 pb-6 border-b border-slate-800">
+    <div class="flex items-center gap-4">
+      <div class="w-12 h-12 rounded-full bg-cyan-400/10 border border-cyan-400/20 flex items-center justify-center">
+        <span class="material-symbols-outlined text-cyan-400 text-2xl">campaign</span>
+      </div>
+      <div>
+        <h3 class="text-2xl font-headline font-bold text-on-surface" th:text="${notice.noticeTitle}">공지 제목</h3>
+        <p class="text-xs text-slate-500 font-label uppercase tracking-widest mt-1"
+           th:text="|AGENT: ${notice.authorName} · ${#temporals.format(notice.createdAt, 'yyyy.MM.dd HH:mm')}|">요원명 · 날짜</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="text-slate-200 leading-relaxed font-body text-base whitespace-pre-wrap min-h-[300px]"
+       th:text="${notice.noticeContent}">
+    여기에 "오호이야오호이야..." 하는 긴 본문 내용이 줄바꿈 그대로 출력됩니다.
+  </div>
+
+  <div th:if="${notice.updatedAt != null and notice.updatedAt != notice.createdAt}"
+       class="mt-10 pt-4 border-t border-slate-800/50 text-[10px] text-slate-600 font-label italic text-right">
+    LAST UPDATED: <span th:text="${#temporals.format(notice.updatedAt, 'yyyy-MM-dd HH:mm')}"></span>
+  </div>
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/student/notice-list.html
+++ b/src/main/resources/templates/student/notice-list.html
@@ -10,6 +10,20 @@
         body { font-family: 'Inter', sans-serif; background-color: #0b0e14; color: #ecedf6; }
         .font-headline { font-family: 'Space Grotesk', sans-serif; }
     </style>
+
+    <style>
+        .line-clamp-2 {
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            /* 아래 속성들을 확인해보세요! */
+            word-break: break-all;
+            min-height: 0; /* 최소 높이를 0으로 잡아줍니다 */
+        }
+    </style>
+
 </head>
 <body class="min-h-screen pt-24 px-6 md:px-12 pb-12 max-w-4xl mx-auto">
 
@@ -39,13 +53,21 @@
             </div>
         </div>
 
-        <div class="text-slate-300 leading-relaxed font-body text-sm whitespace-pre-wrap"
-             th:text="${notice.noticeContent}">공지 본문 내용이 여기에 출력됩니다.</div>
+        <div class="text-slate-300 leading-snug font-body text-sm line-clamp-2 mb-4"
+             th:text="${notice.noticeContent}"></div>
+
+        <div class="text-right mb-4">
+            <a th:href="@{/student/notice/{id}(id=${notice.noticeId})}"
+               class="inline-block text-[10px] font-headline font-bold text-cyan-400 border border-cyan-400/30 px-3 py-1 rounded-full hover:bg-cyan-400/10 transition-all uppercase tracking-tighter">
+                Full Briefing View →
+            </a>
+        </div>
 
         <div th:if="${notice.updatedAt != null and notice.updatedAt != notice.createdAt}"
-             class="mt-6 pt-4 border-t border-slate-800/50 text-[10px] text-slate-600 font-label italic text-right">
+             class="pt-4 border-t border-slate-800/50 text-[10px] text-slate-600 font-label italic text-right">
             LAST UPDATED: <span th:text="${#temporals.format(notice.updatedAt, 'yyyy-MM-dd HH:mm')}"></span>
         </div>
+    </div>
     </div>
 
     <div th:if="${#lists.isEmpty(notices)}" class="py-32 text-center">


### PR DESCRIPTION
## 관련 이슈
Closes #181 

## 작업 브랜치
- feature-lty

## 작업 목적
- 기능 구현

## 변경 사항
- {기능} 강좌 공지사항 상세 조회 기능 추가
- 리펙토링 : 기존에 그냥 공지사항이 몇줄이던간에 쭉 뜨던것을 막고 상세 조회 버튼 달았음

### 상세 변경 내용
1.
2.
3.

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

