### PR TITLE
[refactor] ModelMapper 중도 추가로 인한 기존 방식 리팩토링

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/coursecommand/dto/CourseFindDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursecommand/dto/CourseFindDTO.java
@@ -14,7 +14,7 @@ public class CourseFindDTO {
 
     private Long courseId;
     private String courseTitle;
-    private Long continent;
+    private Long continentId;
     private String courseDescription;
     private Integer coursePrice;
     private String courseThumbnailUrl;

--- a/src/main/java/com/wanted/ailienlmsprogram/coursecommand/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursecommand/service/CourseCommandService.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.ArrayList;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -125,23 +124,15 @@ public class CourseCommandService {
 
     public List<CourseFindDTO> findMyCourses(Long memberId, CourseStatus courseStatus) {
 
-        List<Course> courses = courseRepository.findByInstructor_MemberIdAndCourseStatus(memberId,courseStatus);
-        List<CourseFindDTO> result = new ArrayList<>();
+        List<Course> courses = courseRepository.findByInstructor_MemberIdAndCourseStatus(memberId, courseStatus);
 
-        for (Course course : courses) {
-            CourseFindDTO courseDTO = new CourseFindDTO();
-            courseDTO.setCourseId(course.getCourseId());
-            courseDTO.setCourseTitle(course.getCourseTitle());
-            courseDTO.setCourseDescription(course.getCourseDescription());
-            courseDTO.setContinent(course.getContinent().getContinentId());
-            courseDTO.setCoursePrice(course.getCoursePrice());
-            courseDTO.setCourseThumbnailUrl(course.getCourseThumbnailUrl());
-            courseDTO.setCourseStatus(course.getCourseStatus());
-            courseDTO.setCreatedAt(course.getCreatedAt());
-            result.add(courseDTO);
-        }
-
-        return result;
+        return courses.stream()
+                .map(course -> {
+                    CourseFindDTO dto = modelMapper.map(course, CourseFindDTO.class);
+                    dto.setContinentId(course.getContinent().getContinentId());
+                    return dto;
+                })
+                .collect(Collectors.toList());
     }
 
     @Transactional
@@ -174,17 +165,9 @@ public class CourseCommandService {
         Course course = courseRepository.findById(courseId)
                 .orElseThrow(RuntimeException::new);
 
-        CourseFindDTO courseDTO = new CourseFindDTO();
-        courseDTO.setCourseId(course.getCourseId());
-        courseDTO.setCourseTitle(course.getCourseTitle());
-        courseDTO.setCourseDescription(course.getCourseDescription());
-        courseDTO.setContinent(course.getContinent().getContinentId());
-        courseDTO.setCoursePrice(course.getCoursePrice());
-        courseDTO.setCourseThumbnailUrl(course.getCourseThumbnailUrl());
-        courseDTO.setCourseStatus(course.getCourseStatus());
-        courseDTO.setCreatedAt(course.getCreatedAt());
-
-        return courseDTO;
+        CourseFindDTO dto = modelMapper.map(course, CourseFindDTO.class);
+        dto.setContinentId(course.getContinent().getContinentId());
+        return dto;
     }
 
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/coursenotice/service/CourseNoticeService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursenotice/service/CourseNoticeService.java
@@ -11,6 +11,7 @@ import com.wanted.ailienlmsprogram.enrollment.repository.EnrollmentRepository;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import com.wanted.ailienlmsprogram.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,7 @@ public class CourseNoticeService {
     private final CourseRepository courseRepository;
     private final MemberRepository memberRepository;
     private final EnrollmentRepository enrollmentRepository;
+    private final ModelMapper modelMapper;
 
     // ===== 조회 =====
 
@@ -51,14 +53,11 @@ public class CourseNoticeService {
                 .findByCourse_CourseIdOrderByCreatedAtDesc(courseId);
 
         return notices.stream()
-                .map(notice -> new CourseNoticeFindDTO(
-                        notice.getNoticeId(),
-                        notice.getNoticeTitle(),
-                        notice.getNoticeContent(),
-                        notice.getAuthor().getName(),   // 작성자 이름
-                        notice.getCreatedAt(),
-                        notice.getUpdatedAt()
-                ))
+                .map(notice -> {
+                    CourseNoticeFindDTO dto = modelMapper.map(notice, CourseNoticeFindDTO.class);
+                    dto.setAuthorName(notice.getAuthor().getName());
+                    return dto;
+                })
                 .collect(Collectors.toList());
     }
 
@@ -68,14 +67,9 @@ public class CourseNoticeService {
         CourseNotice notice = courseNoticeRepository.findById(noticeId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 공지사항입니다."));
 
-        return new CourseNoticeFindDTO(
-                notice.getNoticeId(),
-                notice.getNoticeTitle(),
-                notice.getNoticeContent(),
-                notice.getAuthor().getName(),
-                notice.getCreatedAt(),
-                notice.getUpdatedAt()
-        );
+        CourseNoticeFindDTO dto = modelMapper.map(notice, CourseNoticeFindDTO.class);
+        dto.setAuthorName(notice.getAuthor().getName());
+        return dto;
     }
 
     // ===== 등록 =====

--- a/src/main/java/com/wanted/ailienlmsprogram/user/service/UserService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.wanted.ailienlmsprogram.user.dto.UserEditDTO;
 import com.wanted.ailienlmsprogram.user.entity.User;
 import com.wanted.ailienlmsprogram.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
@@ -21,21 +22,13 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final ResourceLoader resourceLoader;
+    private final ModelMapper modelMapper;
 
     public UserFindDTO findUserById(Long memberId) {
         User user = userRepository.findById(memberId)
                 .orElseThrow(RuntimeException::new);
 
-        UserFindDTO dto = new UserFindDTO();
-        dto.setLoginId(user.getLoginId());
-        dto.setEmail(user.getEmail());
-        dto.setName(user.getName());
-        dto.setPhone(user.getPhone());
-        dto.setProfileImageUrl(user.getProfileImageUrl());
-        dto.setRole(user.getRole());
-        dto.setRank(user.getRank());
-        dto.setIntroduction(user.getIntroduction());
-        return dto;
+        return modelMapper.map(user, UserFindDTO.class);
     }
 
     @Transactional

--- a/src/main/resources/templates/course/edit.html
+++ b/src/main/resources/templates/course/edit.html
@@ -287,7 +287,7 @@
                                     <option th:each="continent : ${continents}"
                                             th:value="${continent.continentId}"
                                             th:text="${continent.continentName}"
-                                            th:selected="${continent.continentId == course.continent}"></option>
+                                            th:selected="${continent.continentId == course.continentId}"></option>
                                 </select>
                             </div>
 


### PR DESCRIPTION
## 관련 이슈
Closes #171 

## 작업 브랜치
- refactor/modelMapper

## 작업 목적
- ModelMapper 중도 추가로인한 기존 수동방식 변경(ModelMapper 방식으로 통일)

## 변경 사항
- `user` 패키지 / `coursecommand` 패키지 / `coursenotice` 패키지
- Service, HTML

## 상세 변경 내용
1. `UserService.findUserById()` — 수동 setter → `modelMapper.map()` 교체
2. `CourseCommandService.findMyCourses()` — for문 수동 매핑 → `modelMapper.map()` 교체, `setContinent()` 수동 보완 유지
3. `CourseCommandService.findCourseById()` — 수동 매핑 → `modelMapper.map()` 교체, `setContinent()` 수동 보완 유지
4. `CourseNoticeService.findNotices()` — 수동 생성자 → `modelMapper.map()` 교체, `setAuthorName()` 수동 보완 유지
5. `CourseNoticeService.findNoticeById()` — 수동 생성자 → `modelMapper.map()` 교체, `setAuthorName()` 수동 보완 유지
6. `CourseFindDTO.continent` 필드명 → `continentId` 로 변경
7. `course/edit.html` — `course.continent` → `course.continentId` 로 수정

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

