### PR TITLE
feat : 댓글 비속어 filtering 적용

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/community/controller/CommentController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/controller/CommentController.java
@@ -1,10 +1,14 @@
 package com.wanted.ailienlmsprogram.community.controller;
 
+import com.wanted.ailienlmsprogram.community.dto.CommentRequestDTO; // 1. DTO 임포트 확인
 import com.wanted.ailienlmsprogram.community.service.CommentService;
+import com.wanted.ailienlmsprogram.community.service.PostService;
+import com.wanted.ailienlmsprogram.global.filtering.BadWordDetectedException;
 import com.wanted.ailienlmsprogram.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 @Controller
@@ -13,17 +17,38 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
 
     private final CommentService commentService;
+    private final PostService postService;
 
-    // 댓글 등록
+    // 댓글 등록 (DTO 방식으로 수정)
     @PostMapping
     public String createComment(@PathVariable Long postId,
-                                @RequestParam String content,
-                                @AuthenticationPrincipal CustomUserDetails userDetails) {
-        commentService.saveComment(postId, content, userDetails.getMember());
-        return "redirect:/posts/" + postId;
+                                @ModelAttribute CommentRequestDTO request, // 2. @RequestParam String content 대신 DTO로 받기
+                                @AuthenticationPrincipal CustomUserDetails userDetails,
+                                Model model) {
+
+        try {
+            // 3. 서비스에 DTO(request)를 통째로 넘깁니다. (타입 불일치 해결!)
+            commentService.saveComment(postId, request, userDetails.getMember());
+            return "redirect:/posts/" + postId;
+
+        } catch (BadWordDetectedException e) {
+            // 욕설 감지 시 데이터를 다시 담아 상세 페이지로!
+            model.addAttribute("post", postService.findPostById(postId));
+            model.addAttribute("comments", commentService.findComments(postId));
+            model.addAttribute("errorMessage", e.getMessage());
+
+            // 4. 작성 중이던 댓글 내용을 HTML로 다시 보내기 (데이터 유지의 핵심)
+            model.addAttribute("commentRequestDTO", request);
+
+            if (userDetails != null) {
+                model.addAttribute("currentUserId", String.valueOf(userDetails.getMember().getMemberId()));
+            }
+
+            return "community/post_detail";
+        }
     }
 
-    // 댓글 삭제
+    // 댓글 삭제 (기존 동일)
     @PostMapping("/{commentId}/delete")
     public String deleteComment(@PathVariable Long postId,
                                 @PathVariable Long commentId,

--- a/src/main/java/com/wanted/ailienlmsprogram/community/controller/PostController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/controller/PostController.java
@@ -1,10 +1,12 @@
 package com.wanted.ailienlmsprogram.community.controller;
 
-import com.wanted.ailienlmsprogram.community.dto.PostCreateRequest;
+import com.wanted.ailienlmsprogram.community.dto.CommentRequestDTO; // 1. 댓글 요청 DTO 임포트 추가
+import com.wanted.ailienlmsprogram.community.dto.PostCreateRequestDTO;
 import com.wanted.ailienlmsprogram.community.dto.PostDTO;
-import com.wanted.ailienlmsprogram.community.dto.CommentResponse;
+import com.wanted.ailienlmsprogram.community.dto.CommentResponseDTO;
 import com.wanted.ailienlmsprogram.community.service.PostService;
 import com.wanted.ailienlmsprogram.community.service.CommentService;
+import com.wanted.ailienlmsprogram.global.filtering.BadWordDetectedException;
 import com.wanted.ailienlmsprogram.global.security.CustomUserDetails;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +25,7 @@ import java.util.List;
 public class PostController {
 
     private final PostService postService;
-    private final CommentService commentService; // 댓글 서비스 주입 추가
+    private final CommentService commentService;
 
     // 목록 페이지 이동
     @GetMapping("/continents/{continentId}/posts")
@@ -34,22 +36,22 @@ public class PostController {
         return "community/posts";
     }
 
-    // 상세 페이지 이동
+    // 상세 페이지 이동 (수정됨)
     @GetMapping("/posts/{postId}")
     public String findPostDetail(@PathVariable Long postId,
                                  Model model,
                                  @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        // 1. 게시글 정보 가져오기
         PostDTO post = postService.findPostById(postId);
         model.addAttribute("post", post);
 
-        // 2. 댓글 목록 가져와서 모델에 담기★
-        // 서비스의 findComments 메서드를 호출해서 'comments'라는 이름으로 넘김
-        List<CommentResponse> comments = commentService.findComments(postId);
+        List<CommentResponseDTO> comments = commentService.findComments(postId);
         model.addAttribute("comments", comments);
 
-        // 현재 로그인 유저 정보 처리
+        // ★ 핵심: 상세 페이지를 처음 열 때 빈 댓글 DTO를 모델에 담아줍니다.
+        // 이래야 html의 th:object="${commentRequestDTO}" 가 에러 없이 작동합니다.
+        model.addAttribute("commentRequestDTO", new CommentRequestDTO());
+
         if (userDetails != null) {
             String currentUserId = String.valueOf(userDetails.getMember().getMemberId());
             model.addAttribute("currentUserId", currentUserId);
@@ -62,21 +64,30 @@ public class PostController {
     @GetMapping("/continents/{continentId}/posts/new")
     public String createPostForm(@PathVariable Long continentId, Model model) {
         model.addAttribute("continentId", continentId);
-        model.addAttribute("postCreateRequest", new PostCreateRequest());
+        model.addAttribute("postCreateRequest", new PostCreateRequestDTO());
         return "community/post_create";
     }
 
     // 새 글 저장 처리
     @PostMapping("/continents/{continentId}/posts/new")
     public String createPost(@PathVariable Long continentId,
-                             @ModelAttribute PostCreateRequest request,
-                             @AuthenticationPrincipal CustomUserDetails userDetails) {
+                             @ModelAttribute PostCreateRequestDTO request,
+                             @AuthenticationPrincipal CustomUserDetails userDetails,
+                             Model model) {
 
-        Member loginMember = userDetails.getMember();
-        request.setContinentId(continentId);
-        postService.savePost(request, loginMember);
+        try {
+            Member loginMember = userDetails.getMember();
+            request.setContinentId(continentId);
+            postService.savePost(request, loginMember);
 
-        return "redirect:/continents/" + continentId + "/posts";
+            return "redirect:/continents/" + continentId + "/posts";
+
+        } catch (BadWordDetectedException e) {
+            model.addAttribute("continentId", continentId);
+            model.addAttribute("postCreateRequest", request);
+            model.addAttribute("errorMessage", e.getMessage());
+            return "community/post_create";
+        }
     }
 
     // 수정 화면 이동
@@ -90,9 +101,18 @@ public class PostController {
     // 수정 처리
     @PostMapping("/continents/posts/edit/{postId}")
     public String updatePost(@PathVariable Long postId,
-                             @ModelAttribute PostCreateRequest request) {
-        postService.updatePost(postId, request);
-        return "redirect:/posts/" + postId;
+                             @ModelAttribute PostCreateRequestDTO request,
+                             Model model) {
+        try {
+            postService.updatePost(postId, request);
+            return "redirect:/posts/" + postId;
+
+        } catch (BadWordDetectedException e) {
+            model.addAttribute("postId", postId);
+            model.addAttribute("post", request);
+            model.addAttribute("errorMessage", e.getMessage());
+            return "community/post_update";
+        }
     }
 
     // 삭제 처리
@@ -104,8 +124,4 @@ public class PostController {
         postService.deletePost(postId);
         return "redirect:/continents/" + continentId + "/posts";
     }
-
-
-
-
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/community/controller/ReportController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/controller/ReportController.java
@@ -1,6 +1,6 @@
 package com.wanted.ailienlmsprogram.community.controller;
 
-import com.wanted.ailienlmsprogram.community.dto.ReportRequest;
+import com.wanted.ailienlmsprogram.community.dto.ReportRequestDTO;
 import com.wanted.ailienlmsprogram.community.service.ReportService;
 import com.wanted.ailienlmsprogram.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +17,7 @@ public class ReportController {
 
     @PostMapping
     public ResponseEntity<String> submitReport(
-            @RequestBody ReportRequest request,
+            @RequestBody ReportRequestDTO request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         Long reporterNo = userDetails.getMember().getMemberId();

--- a/src/main/java/com/wanted/ailienlmsprogram/community/dto/CommentRequestDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/dto/CommentRequestDTO.java
@@ -1,0 +1,10 @@
+package com.wanted.ailienlmsprogram.community.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CommentRequestDTO {
+    private String content; // 댓글 내용
+}

--- a/src/main/java/com/wanted/ailienlmsprogram/community/dto/CommentResponseDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/dto/CommentResponseDTO.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CommentResponse {
+public class CommentResponseDTO {
     private Long commentId;
     private String content;
     private String memberName; // 작성자 이름

--- a/src/main/java/com/wanted/ailienlmsprogram/community/dto/PostCreateRequestDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/dto/PostCreateRequestDTO.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class PostCreateRequest {
+public class PostCreateRequestDTO {
     private String postTitle;   // 제목을 담을 칸
     private String postContent; // 내용을 담을 칸
     private Long continentId;   // 대륙 번호를 담을 칸

--- a/src/main/java/com/wanted/ailienlmsprogram/community/dto/ReportRequestDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/dto/ReportRequestDTO.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ReportRequest {
+public class ReportRequestDTO {
     private String targetType;
     private Long targetNo;
     private String reason;

--- a/src/main/java/com/wanted/ailienlmsprogram/community/service/CommentService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/service/CommentService.java
@@ -1,10 +1,12 @@
 package com.wanted.ailienlmsprogram.community.service;
 
-import com.wanted.ailienlmsprogram.community.dto.CommentResponse;
+import com.wanted.ailienlmsprogram.community.dto.CommentRequestDTO; // 1. 새로 만든 DTO 임포트
+import com.wanted.ailienlmsprogram.community.dto.CommentResponseDTO;
 import com.wanted.ailienlmsprogram.community.entity.CommunityComment;
 import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
 import com.wanted.ailienlmsprogram.community.repository.CommentRepository;
 import com.wanted.ailienlmsprogram.community.repository.PostRepository;
+import com.wanted.ailienlmsprogram.global.filtering.BadWordCheck;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,19 +22,19 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
 
-    // 댓글 쓰기 (공지글 체크)
+    // 댓글 쓰기 (DTO를 사용하도록 수정)
     @Transactional
-    public void saveComment(Long postId, String content, Member member) {
+    @BadWordCheck // ★ AOP가 DTO 내부의 content 필드를 감시합니다.
+    public void saveComment(Long postId, CommentRequestDTO request, Member member) { // 2. String 대신 DTO로 변경
         CommunityPost post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글이 없습니다."));
-
 
         if (post.getPostTitle().startsWith("[공지]")) {
             throw new IllegalStateException("공지사항에는 댓글을 달 수 없습니다.");
         }
 
         CommunityComment comment = CommunityComment.builder()
-                .content(content)
+                .content(request.getContent()) // 3. DTO에서 내용을 꺼내서 저장
                 .post(post)
                 .member(member)
                 .isDeleted(false)
@@ -40,26 +42,24 @@ public class CommentService {
         commentRepository.save(comment);
     }
 
-    // 댓글 목록 조회
-    public List<CommentResponse> findComments(Long postId) {
-
+    // 댓글 목록 조회 (기존 유지)
+    public List<CommentResponseDTO> findComments(Long postId) {
         return commentRepository.findByPostPostIdAndIsDeletedFalse(postId).stream()
-                .map(comment -> CommentResponse.builder()
+                .map(comment -> CommentResponseDTO.builder()
                         .commentId(comment.getCommentId())
                         .content(comment.getContent())
-                        .memberName(comment.getMember().getName()) // memberName -> name 으로 수정
-                        .memberId(comment.getMember().getMemberId()) // memberId 유지
+                        .memberName(comment.getMember().getName())
+                        .memberId(comment.getMember().getMemberId())
                         .build())
                 .collect(Collectors.toList());
     }
 
-    // 댓글 삭제
+    // 댓글 삭제 (기존 유지)
     @Transactional
     public void deleteComment(Long commentId, Member loginMember) {
         CommunityComment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
 
-        // 본인 확인
         if (!comment.getMember().getMemberId().equals(loginMember.getMemberId())) {
             throw new IllegalStateException("본인이 작성한 댓글만 삭제할 수 있습니다.");
         }

--- a/src/main/java/com/wanted/ailienlmsprogram/community/service/PostService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/service/PostService.java
@@ -1,9 +1,10 @@
 package com.wanted.ailienlmsprogram.community.service;
 
-import com.wanted.ailienlmsprogram.community.dto.PostCreateRequest;
+import com.wanted.ailienlmsprogram.community.dto.PostCreateRequestDTO;
 import com.wanted.ailienlmsprogram.community.dto.PostDTO;
 import com.wanted.ailienlmsprogram.community.repository.PostRepository;
 import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
+import com.wanted.ailienlmsprogram.global.filtering.BadWordCheck;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,7 +35,8 @@ public class PostService {
     }
 
     @Transactional
-    public void savePost(PostCreateRequest request, Member member) {
+    @BadWordCheck
+    public void savePost(PostCreateRequestDTO request, Member member) {
         // 학생용 서비스이므로 postIsNotice는 무조건 false(0)로 고정!
         CommunityPost post = CommunityPost.builder()
                 .postTitle(request.getPostTitle())
@@ -49,7 +51,8 @@ public class PostService {
     }
 
     @Transactional
-    public void updatePost(Long postId, PostCreateRequest request) {
+    @BadWordCheck
+    public void updatePost(Long postId, PostCreateRequestDTO request) {
         CommunityPost post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다. ID: " + postId));
 

--- a/src/main/resources/templates/community/post_create.html
+++ b/src/main/resources/templates/community/post_create.html
@@ -9,7 +9,13 @@
 <div class="container">
     <h1 style="color: #ff9d00;">> NEW POST // 새 글 작성</h1>
     <p style="color: #888;">대륙 침공 작전을 기록하십시오.</p>
-    <hr style="border: 0.5px solid #333;">
+    <hr style="border: 0.5px solid #333; margin-bottom: 30px;">
+
+    <div th:if="${errorMessage}"
+         style="margin-bottom: 20px; padding: 12px 16px; background: #2a1212; border: 1px solid #ff6b6b; color: #ffb4b4; border-radius: 6px; font-size: 14px;"
+         th:text="${errorMessage}">
+        에러 메시지
+    </div>
 
     <form th:action="@{/continents/{id}/posts/new(id=${continentId})}"
           th:object="${postCreateRequest}" method="post">
@@ -18,12 +24,24 @@
             <label style="display: block; margin-bottom: 10px;">작전 제목</label>
             <input type="text" th:field="*{postTitle}" placeholder="제목을 입력하세요"
                    style="width: 100%; padding: 15px; background: #1a1d23; border: 1px solid #444; color: white; border-radius: 5px;" required>
+
+            <div th:if="${#fields.hasErrors('postTitle')}"
+                 th:errors="*{postTitle}"
+                 style="margin-top: 8px; color: #ff7b7b; font-size: 13px;">
+                제목 오류
+            </div>
         </div>
 
         <div style="margin-bottom: 20px;">
             <label style="display: block; margin-bottom: 10px;">세부 작전 내용</label>
             <textarea th:field="*{postContent}" rows="10" placeholder="내용을 입력하세요"
                       style="width: 100%; padding: 15px; background: #1a1d23; border: 1px solid #444; color: white; border-radius: 5px; resize: none;" required></textarea>
+
+            <div th:if="${#fields.hasErrors('postContent')}"
+                 th:errors="*{postContent}"
+                 style="margin-top: 8px; color: #ff7b7b; font-size: 13px;">
+                내용 오류
+            </div>
         </div>
 
         <div class="btn-group">

--- a/src/main/resources/templates/community/post_detail.html
+++ b/src/main/resources/templates/community/post_detail.html
@@ -15,7 +15,18 @@
         .btn { display: inline-block; padding: 12px 25px; border-radius: 8px; background: #5f7cff; color: white; text-decoration: none; font-weight: bold; cursor: pointer; border: none; font-size: 16px; }
         .btn-list { background: #1d295f; }
         .btn-delete { background: #ff5f5f; }
-        .btn-report { background: #4b5563; } /* 신고 버튼용 회색 */
+        .btn-report { background: #4b5563; }
+
+        /* ★ 추가: 비속어 경고창 스타일 */
+        .error-box {
+            margin-bottom: 20px;
+            padding: 12px 16px;
+            background: #2a1212;
+            border: 1px solid #ff6b6b;
+            color: #ffb4b4;
+            border-radius: 6px;
+            font-size: 14px;
+        }
     </style>
 </head>
 <body>
@@ -50,11 +61,19 @@
 <div class="container" th:if="${!post.postIsNotice}" style="margin-top: 50px; border-top: 1px solid #3d4450; padding-top: 30px;">
     <h3 style="color: #7ee0ff; margin-bottom: 20px;">💬 댓글</h3>
 
+    <div th:if="${errorMessage}" class="error-box" th:text="${errorMessage}">
+        에러 메시지
+    </div>
+
     <div class="comment-write" style="margin-bottom: 40px;">
-        <form th:action="@{/posts/{postId}/comments(postId=${post.postId})}" method="post">
+        <form th:action="@{/posts/{postId}/comments(postId=${post.postId})}"
+              th:object="${commentRequestDTO}" method="post">
+
             <input type="hidden" th:name="_csrf" th:value="${_csrf?.token}" />
-            <textarea name="content" required placeholder="따뜻한 댓글을 남겨주세요."
+
+            <textarea th:field="*{content}" required placeholder="따뜻한 댓글을 남겨주세요."
                       style="width: 100%; height: 100px; background: #121a35; color: white; border: 1px solid #3d4450; border-radius: 10px; padding: 15px; resize: none;"></textarea>
+
             <div style="text-align: right; margin-top: 10px;">
                 <button type="submit" class="btn" style="background-color: #5d7cff;">댓글 등록</button>
             </div>


### PR DESCRIPTION
## 관련 이슈
Closes #178 

## 작업 브랜치
- ex) feat/community-0416

## 작업 목적
- 댓글에도 flitering을 적용해서 비속어를 포함한 댓글을 사용할 수 없도록 한다.

## 변경 사항
- commentrequestDTO  추가

### 상세 변경 내용
1. 댓글에 비속어를 포함하면 댓글을 작성할 수 없다.

## 테스트 내용
- [ ] 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] 로컬 실행 확인

