### PR TITLE
예외 처리 통일

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminReportCommandRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminReportCommandRepository.java
@@ -4,6 +4,8 @@ import com.wanted.ailienlmsprogram.community.entity.CommunityComment;
 import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
 import com.wanted.ailienlmsprogram.community.entity.Report;
 import com.wanted.ailienlmsprogram.qna.entity.Qna;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
@@ -18,7 +20,7 @@ public class AdminReportCommandRepository {
         Report report = em.find(Report.class, reportId);
 
         if (report == null) {
-            throw new IllegalArgumentException("존재하지 않는 신고입니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 신고입니다.");
         }
 
         switch (report.getTargetType()) {
@@ -32,7 +34,7 @@ public class AdminReportCommandRepository {
         CommunityPost post = em.find(CommunityPost.class, postId);
 
         if (post == null) {
-            throw new IllegalArgumentException("삭제할 게시글이 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "삭제할 게시글이 존재하지 않습니다.");
         }
 
         if (!post.isPostIsDeleted()) {
@@ -44,7 +46,7 @@ public class AdminReportCommandRepository {
         CommunityComment comment = em.find(CommunityComment.class, commentId);
 
         if (comment == null) {
-            throw new IllegalArgumentException("삭제할 댓글이 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "삭제할 댓글이 존재하지 않습니다.");
         }
 
         if (!comment.isDeleted()) {
@@ -56,7 +58,7 @@ public class AdminReportCommandRepository {
         Qna qna = em.find(Qna.class, qnaId);
 
         if (qna == null) {
-            throw new IllegalArgumentException("삭제할 Q&A가 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "삭제할 Q&A가 존재하지 않습니다.");
         }
 
         if (!qna.isQnaIsDeleted()) {

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminReportQueryRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminReportQueryRepository.java
@@ -7,8 +7,12 @@ import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
 import com.wanted.ailienlmsprogram.community.entity.Report;
 import com.wanted.ailienlmsprogram.community.entity.TargetType;
 import com.wanted.ailienlmsprogram.continent.entity.Continent;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import com.wanted.ailienlmsprogram.qna.entity.Qna;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import org.springframework.stereotype.Repository;
@@ -76,7 +80,7 @@ public class AdminReportQueryRepository {
         Report report = em.find(Report.class, reportId);
 
         if (report == null) {
-            throw new IllegalArgumentException("존재하지 않는 신고입니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 신고입니다.");
         }
 
         Member reporter = report.getReporterNo() != null ? em.find(Member.class, report.getReporterNo()) : null;

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminContinentNoticeService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminContinentNoticeService.java
@@ -6,6 +6,8 @@ import com.wanted.ailienlmsprogram.admin.dto.AdminContinentNoticeFormRequest;
 import com.wanted.ailienlmsprogram.admin.dto.AdminContinentNoticeListResponse;
 import com.wanted.ailienlmsprogram.admin.repository.AdminContinentNoticeQueryRepository;
 import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import com.wanted.ailienlmsprogram.global.filtering.BadWordCheck;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +49,7 @@ public class AdminContinentNoticeService {
                 adminContinentNoticeQueryRepository.findNoticeDetail(continentId, postId);
 
         if (detail == null) {
-            throw new IllegalArgumentException("해당 대륙의 공지글을 찾을 수 없습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "해당 대륙의 공지글을 찾을 수 없습니다.");
         }
 
         return detail;
@@ -86,25 +88,25 @@ public class AdminContinentNoticeService {
 
     private CommunityPost getTargetNotice(Long continentId, Long postId) {
         if (postId == null) {
-            throw new IllegalArgumentException("공지글 정보가 없습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "공지글 정보가 없습니다.");
         }
 
         CommunityPost post = adminContinentNoticeQueryRepository.findPost(postId);
 
         if (post == null) {
-            throw new IllegalArgumentException("공지글이 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "공지글이 존재하지 않습니다.");
         }
 
         if (!Objects.equals(post.getContinentId(), continentId)) {
-            throw new IllegalArgumentException("선택한 대륙의 공지글이 아닙니다.");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "선택한 대륙의 공지글이 아닙니다.");
         }
 
         if (post.isPostIsDeleted()) {
-            throw new IllegalArgumentException("이미 삭제된 공지글입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 삭제된 공지글입니다.");
         }
 
         if (!post.isPostIsNotice()) {
-            throw new IllegalArgumentException("관리자 공지글만 수정/삭제할 수 있습니다.");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "관리자 공지글만 수정/삭제할 수 있습니다.");
         }
 
         return post;
@@ -114,7 +116,7 @@ public class AdminContinentNoticeService {
         Member member = adminContinentNoticeQueryRepository.findMember(adminMemberId);
 
         if (member == null) {
-            throw new IllegalArgumentException("관리자 계정 정보를 찾을 수 없습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "관리자 계정 정보를 찾을 수 없습니다.");
         }
 
         return member;
@@ -122,11 +124,11 @@ public class AdminContinentNoticeService {
 
     private void validateContinent(Long continentId) {
         if (continentId == null) {
-            throw new IllegalArgumentException("대륙 정보가 없습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "대륙 정보가 없습니다.");
         }
 
         if (adminContinentNoticeQueryRepository.findContinentEntity(continentId) == null) {
-            throw new IllegalArgumentException("대륙이 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "대륙이 존재하지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminCourseService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminCourseService.java
@@ -6,6 +6,8 @@ import com.wanted.ailienlmsprogram.admin.dto.AdminCourseSearchCondition;
 import com.wanted.ailienlmsprogram.admin.repository.AdminCourseQueryRepository;
 import com.wanted.ailienlmsprogram.coursecommand.entity.Course;
 import com.wanted.ailienlmsprogram.coursecommand.entity.CourseStatus;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,7 +36,7 @@ public class AdminCourseService {
         AdminCourseDetailResponse detail = adminCourseQueryRepository.findCourseDetail(courseId);
 
         if (detail == null) {
-            throw new IllegalArgumentException("강좌가 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "강좌가 존재하지 않습니다.");
         }
 
         return detail;
@@ -45,17 +47,17 @@ public class AdminCourseService {
         Course course = getTarget(courseId);
 
         if (targetStatus == null) {
-            throw new IllegalArgumentException("변경할 강좌 상태가 없습니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "변경할 강좌 상태가 없습니다.");
         }
 
         if (course.getCourseStatus() == targetStatus) {
-            throw new IllegalArgumentException("이미 해당 상태로 설정된 강좌입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 해당 상태로 설정된 강좌입니다.");
         }
 
         int updatedCount = adminCourseQueryRepository.updateCourseStatus(courseId, targetStatus);
 
         if (updatedCount == 0) {
-            throw new IllegalArgumentException("강좌 상태 변경에 실패했습니다.");
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "강좌 상태 변경에 실패했습니다.");
         }
     }
 
@@ -64,7 +66,7 @@ public class AdminCourseService {
         Course course = adminCourseQueryRepository.findCourse(courseId);
 
         if (course == null) {
-            throw new IllegalArgumentException("강좌가 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "강좌가 존재하지 않습니다.");
         }
 
         return course;

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminInstructorService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminInstructorService.java
@@ -3,6 +3,8 @@ package com.wanted.ailienlmsprogram.admin.service;
 import com.wanted.ailienlmsprogram.admin.dto.AdminInstructorCreateRequest;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import com.wanted.ailienlmsprogram.member.repository.MemberRepository;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -43,11 +45,11 @@ public class AdminInstructorService {
     // 강사 생성 요청의 중복 데이터를 검증한다.
     private void validateDuplicate(AdminInstructorCreateRequest request) {
         if (memberRepository.existsByLoginId(request.getLoginId())) {
-            throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 아이디입니다.");
         }
 
         if (memberRepository.existsByEmail(request.getEmail())) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 이메일입니다.");
         }
     }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminMemberService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminMemberService.java
@@ -4,6 +4,8 @@ import com.wanted.ailienlmsprogram.admin.dto.AdminMemberListResponse;
 import com.wanted.ailienlmsprogram.admin.dto.AdminMemberSearchCondition;
 import com.wanted.ailienlmsprogram.admin.repository.AdminMemberQueryRepository;
 import com.wanted.ailienlmsprogram.member.entity.Member;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -40,7 +42,7 @@ public class AdminMemberService {
         || member.getAccountStatus() == Member.AccountStatus.INACTIVE) {
             member.activate();
         } else {
-            throw new IllegalArgumentException("처리할 수 없는 계정 상태입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "처리할 수 없는 계정 상태입니다.");
         }
     }
 
@@ -56,7 +58,7 @@ public class AdminMemberService {
     private Member getTarget(Long memberId) {
         Member member = adminMemberQueryRepository.findMember(memberId);
         if (member == null) {
-            throw new IllegalArgumentException("회원이 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "회원이 존재하지 않습니다.");
         }
         return member;
     }
@@ -64,7 +66,7 @@ public class AdminMemberService {
     //관리자 계정인지 검증한다.
     private void validateAdminTarget(Member member) {
         if (member.getRole() == Member.MemberRole.ADMIN) {
-            throw new IllegalArgumentException("관리자 계정은 처리할 수 없습니다.");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "관리자 계정은 처리할 수 없습니다.");
         }
     }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminRefundService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/service/AdminRefundService.java
@@ -8,6 +8,8 @@ import com.wanted.ailienlmsprogram.payment.entity.Payment;
 import com.wanted.ailienlmsprogram.payment.entity.PaymentItem;
 import com.wanted.ailienlmsprogram.payment.entity.Refund;
 import com.wanted.ailienlmsprogram.payment.repository.RefundRepository;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,10 +48,10 @@ public class AdminRefundService {
     @Transactional
     public void approveRefund(Long refundId) {
         Refund refund = refundRepository.findById(refundId)
-                .orElseThrow(() -> new IllegalArgumentException("환불 요청이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "환불 요청이 존재하지 않습니다."));
 
         if (refund.getRefundStatus() != Refund.RefundStatus.REQUESTED) {
-            throw new IllegalArgumentException("처리 대기 중(REQUESTED) 상태의 환불만 승인할 수 있습니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "처리 대기 중(REQUESTED) 상태의 환불만 승인할 수 있습니다.");
         }
 
         Payment payment = refund.getPayment();
@@ -78,10 +80,10 @@ public class AdminRefundService {
     @Transactional
     public void rejectRefund(Long refundId) {
         Refund refund = refundRepository.findById(refundId)
-                .orElseThrow(() -> new IllegalArgumentException("환불 요청이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "환불 요청이 존재하지 않습니다."));
 
         if (refund.getRefundStatus() != Refund.RefundStatus.REQUESTED) {
-            throw new IllegalArgumentException("처리 대기 중(REQUESTED) 상태의 환불만 거절할 수 있습니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "처리 대기 중(REQUESTED) 상태의 환불만 거절할 수 있습니다.");
         }
 
         refund.setRefundStatus(Refund.RefundStatus.REJECTED);

--- a/src/main/java/com/wanted/ailienlmsprogram/community/service/CommentService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/service/CommentService.java
@@ -8,6 +8,8 @@ import com.wanted.ailienlmsprogram.community.repository.CommentRepository;
 import com.wanted.ailienlmsprogram.community.repository.PostRepository;
 import com.wanted.ailienlmsprogram.global.filtering.BadWordCheck;
 import com.wanted.ailienlmsprogram.member.entity.Member;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,10 +29,10 @@ public class CommentService {
     @BadWordCheck // ★ AOP가 DTO 내부의 content 필드를 감시합니다.
     public void saveComment(Long postId, CommentRequestDTO request, Member member) { // 2. String 대신 DTO로 변경
         CommunityPost post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글이 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "게시글이 없습니다."));
 
         if (post.getPostTitle().startsWith("[공지]")) {
-            throw new IllegalStateException("공지사항에는 댓글을 달 수 없습니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "공지사항에는 댓글을 달 수 없습니다.");
         }
 
         CommunityComment comment = CommunityComment.create(request.getContent(), post, member);
@@ -53,10 +55,10 @@ public class CommentService {
     @Transactional
     public void deleteComment(Long commentId, Member loginMember) {
         CommunityComment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "댓글을 찾을 수 없습니다."));
 
         if (!comment.getMember().getMemberId().equals(loginMember.getMemberId())) {
-            throw new IllegalStateException("본인이 작성한 댓글만 삭제할 수 있습니다.");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인이 작성한 댓글만 삭제할 수 있습니다.");
         }
 
         comment.delete();

--- a/src/main/java/com/wanted/ailienlmsprogram/community/service/PostService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/service/PostService.java
@@ -6,6 +6,8 @@ import com.wanted.ailienlmsprogram.community.repository.PostRepository;
 import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
 import com.wanted.ailienlmsprogram.global.filtering.BadWordCheck;
 import com.wanted.ailienlmsprogram.member.entity.Member;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,7 +32,7 @@ public class PostService {
 
     public PostDTO findPostById(Long postId) {
         CommunityPost post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다. ID: " + postId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "게시글을 찾을 수 없습니다. ID: " + postId));
         return new PostDTO(post);
     }
 
@@ -52,7 +54,7 @@ public class PostService {
     @BadWordCheck
     public void updatePost(Long postId, PostCreateRequestDTO request) {
         CommunityPost post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다. ID: " + postId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "게시글을 찾을 수 없습니다. ID: " + postId));
 
         post.setPostTitle(request.getPostTitle());
         post.setPostContent(request.getPostContent());
@@ -61,7 +63,7 @@ public class PostService {
     @Transactional
     public void deletePost(Long postId) {
         CommunityPost post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다. ID: " + postId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "게시글을 찾을 수 없습니다. ID: " + postId));
 
         post.setPostIsDeleted(true);
     }

--- a/src/main/java/com/wanted/ailienlmsprogram/continent/service/ContinentService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/continent/service/ContinentService.java
@@ -3,6 +3,8 @@ package com.wanted.ailienlmsprogram.continent.service;
 import com.wanted.ailienlmsprogram.continent.dto.ContinentAllResponseDTO;
 import com.wanted.ailienlmsprogram.continent.entity.Continent;
 import com.wanted.ailienlmsprogram.continent.repository.ContinentRepository;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
@@ -40,7 +42,7 @@ public class ContinentService {
     public ContinentAllResponseDTO getContinentDetail(Long continentId) {
 
         Continent continent = continentRepository.findById(continentId)
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 대륙입니다."));
 
         ContinentAllResponseDTO continentAllResponseDTO = modelMapper.map(continent, ContinentAllResponseDTO.class);
 

--- a/src/main/java/com/wanted/ailienlmsprogram/coursecommand/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursecommand/service/CourseCommandService.java
@@ -11,6 +11,8 @@ import com.wanted.ailienlmsprogram.coursecommand.entity.Course;
 import com.wanted.ailienlmsprogram.coursecommand.entity.CourseStatus;
 import com.wanted.ailienlmsprogram.user.entity.User;
 import com.wanted.ailienlmsprogram.user.repository.UserRepository;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.AllArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.core.io.Resource;
@@ -83,14 +85,13 @@ public class CourseCommandService {
     public CourseDetailResponseDTO courseDetail(Long courseId) {
 
         Course foundCourse = courseRepository.findById(courseId)
-                .orElseThrow(IllegalArgumentException::new);
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강좌입니다."));
 
         CourseDetailResponseDTO course = modelMapper.map(foundCourse, CourseDetailResponseDTO.class);
 
         if (foundCourse.getInstructor() != null) {
             course.setInstructorName(foundCourse.getInstructor().getName());
         }
-
 
         // 테스트 로직입니다
         course.setCourseDescription("지구를 정복하기 위한 최고의 자바 강의! 일루미나티도 수강 중입니다.");
@@ -128,7 +129,7 @@ public class CourseCommandService {
     public void editMyCourse(MultipartFile thumbnailFile, Long courseId, CourseApplyDTO request) throws IOException {
 
         Course course = courseRepository.findById(courseId)
-                                        .orElseThrow(RuntimeException::new);
+                                        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강좌입니다."));
 
         Continent continent = continentRepository.getReferenceById(request.getContinentId());
 
@@ -152,7 +153,7 @@ public class CourseCommandService {
     public CourseFindDTO findCourseById(Long courseId) {
 
         Course course = courseRepository.findById(courseId)
-                .orElseThrow(RuntimeException::new);
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강좌입니다."));
 
         CourseFindDTO dto = modelMapper.map(course, CourseFindDTO.class);
         dto.setContinentId(course.getContinent().getContinentId());

--- a/src/main/java/com/wanted/ailienlmsprogram/coursenotice/service/CourseNoticeService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursenotice/service/CourseNoticeService.java
@@ -11,13 +11,13 @@ import com.wanted.ailienlmsprogram.enrollment.entity.Enrollment;
 import com.wanted.ailienlmsprogram.enrollment.repository.EnrollmentRepository;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import com.wanted.ailienlmsprogram.member.repository.MemberRepository;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,7 +37,7 @@ public class CourseNoticeService {
     public List<CourseNoticeFindDTO> findNotices(Long courseId, Long memberId) {
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new RuntimeException("Member not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
 
         boolean isEnrolled = enrollmentRepository.existsByMember_LoginIdAndCourse_CourseIdAndStatus(
                 member.getLoginId(),
@@ -47,7 +47,7 @@ public class CourseNoticeService {
         boolean isInstructor = courseRepository.existsByCourseIdAndInstructor_MemberId(courseId, memberId);
 
         if (!isEnrolled && !isInstructor) {
-            throw new AccessDeniedException("비인가 요원 감지! 수강생만 접근 가능한 구역입니다. 오호이야~!");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "수강생만 접근 가능한 구역입니다.");
         }
 
         List<CourseNotice> notices = courseNoticeRepository
@@ -66,7 +66,7 @@ public class CourseNoticeService {
     public CourseNoticeFindDTO findNoticeById(Long noticeId) {
 
         CourseNotice notice = courseNoticeRepository.findById(noticeId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 공지사항입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 공지사항입니다."));
 
         CourseNoticeFindDTO dto = modelMapper.map(notice, CourseNoticeFindDTO.class);
         dto.setAuthorName(notice.getAuthor().getName());
@@ -98,7 +98,7 @@ public class CourseNoticeService {
 
         // 1. 공지사항 조회
         CourseNotice notice = courseNoticeRepository.findById(noticeId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 공지사항입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 공지사항입니다."));
 
         // 2. 엔티티 수정 메서드 호출
         //    → @Transactional + 더티체킹으로 save() 없이 자동 UPDATE
@@ -116,7 +116,7 @@ public class CourseNoticeService {
 
         // 1. 공지사항 조회
         CourseNotice notice = courseNoticeRepository.findById(noticeId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 공지사항입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 공지사항입니다."));
 
         // 2. DB에서 삭제
         courseNoticeRepository.delete(notice);

--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/service/LectureService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/service/LectureService.java
@@ -9,6 +9,8 @@ import com.wanted.ailienlmsprogram.lecture.dto.LectureFindDTO;
 import com.wanted.ailienlmsprogram.lecture.dto.LectureResponseDTO;
 import com.wanted.ailienlmsprogram.lecture.dto.LectureWatchDTO;
 import com.wanted.ailienlmsprogram.lecture.entity.Lecture;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
@@ -85,7 +87,7 @@ public class LectureService {
     public LectureFindDTO findLectureById(Long lectureId) {
 
         Lecture lecture = lectureRepository.findById(lectureId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강의입니다."));
 
         return  modelMapper.map(lecture, LectureFindDTO.class);
 
@@ -96,7 +98,7 @@ public class LectureService {
 
         // 1. 강의 조회
         Lecture lecture = lectureRepository.findById(lectureId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강의입니다."));
 
         // 2. 새 영상이 있을 때만 GCS 처리
         String videoUrl = null;
@@ -125,7 +127,7 @@ public class LectureService {
 
         // 1. 강의 조회
         Lecture lecture = lectureRepository.findById(lectureId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강의입니다."));
 
         // 2. GCS 영상 삭제 (영상이 있을 때만)
         if (lecture.getVideoUrl() != null) {
@@ -138,7 +140,7 @@ public class LectureService {
     public LectureWatchDTO findWatchLecture(Long lectureId) {
 
         Lecture lecture = lectureRepository.findById(lectureId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강의입니다."));
 
         return modelMapper.map(lecture, LectureWatchDTO.class);
     }

--- a/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/service/LectureProgressService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lectureprogress/service/LectureProgressService.java
@@ -8,6 +8,8 @@ import com.wanted.ailienlmsprogram.lectureprogress.dao.LectureProgressRepository
 import com.wanted.ailienlmsprogram.lectureprogress.entity.LectureProgress;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import com.wanted.ailienlmsprogram.member.repository.MemberRepository;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,11 +33,11 @@ public class LectureProgressService {
 
         // 1. 강의 조회
         Lecture lecture = lectureRepository.findById(lectureId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강의입니다."));
 
         // 2. 회원 조회
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
 
         // 3. 이미 완료된 강의면 중복 처리 방지
         Optional<LectureProgress> existing = lectureProgressRepository
@@ -63,7 +65,7 @@ public class LectureProgressService {
         // 6. Enrollment 진척률 업데이트
         Enrollment enrollment = enrollmentRepository
                 .findByMemberMemberIdAndCourseCourseId(memberId, courseId)
-                .orElseThrow(() -> new IllegalArgumentException("수강 정보가 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "수강 정보가 없습니다."));
 
         enrollment.updateProgressRate(progressRate);
 
@@ -84,7 +86,7 @@ public class LectureProgressService {
     // courseId 조회 (컨트롤러에서 redirect용으로 사용)
     public Long findCourseId(Long lectureId) {
         Lecture lecture = lectureRepository.findById(lectureId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강의입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강의입니다."));
         return lecture.getCourse().getCourseId();
     }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/member/service/MemberService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/member/service/MemberService.java
@@ -3,6 +3,8 @@ package com.wanted.ailienlmsprogram.member.service;
 import com.wanted.ailienlmsprogram.member.dto.SignupRequest;
 import com.wanted.ailienlmsprogram.member.entity.Member;
 import com.wanted.ailienlmsprogram.member.repository.MemberRepository;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -28,11 +30,11 @@ public class MemberService {
     @Transactional
     public void signup(SignupRequest request) {
         if (memberRepository.existsByLoginId(request.getLoginId())) {
-            throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 아이디입니다.");
         }
 
         if (memberRepository.existsByEmail(request.getEmail())) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 사용 중인 이메일입니다.");
         }
 
         Member member = Member.create(
@@ -58,7 +60,7 @@ public class MemberService {
     @Transactional
     public void handleLoginSuccess(Long memberId) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "회원이 존재하지 않습니다."));
 
         LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/com/wanted/ailienlmsprogram/payment/client/TossPaymentClient.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/payment/client/TossPaymentClient.java
@@ -1,5 +1,7 @@
 package com.wanted.ailienlmsprogram.payment.client;
 
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import com.wanted.ailienlmsprogram.payment.dto.TossPaymentResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -51,7 +53,7 @@ public class TossPaymentClient {
 
         } catch (RestClientException e) {
             log.error("Toss confirm failed: paymentKey={}, orderId={}", paymentKey, orderId, e);
-            throw new IllegalArgumentException("토스페이먼츠 결제 확인에 실패했습니다.");
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "토스페이먼츠 결제 확인에 실패했습니다.");
         }
     }
 
@@ -78,7 +80,7 @@ public class TossPaymentClient {
                     .toBodilessEntity();
         } catch (RestClientException e) {
             log.error("Toss cancel failed: paymentKey={}", paymentKey, e);
-            throw new IllegalArgumentException("토스페이먼츠 결제 취소에 실패했습니다.");
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "토스페이먼츠 결제 취소에 실패했습니다.");
         }
     }
 

--- a/src/main/java/com/wanted/ailienlmsprogram/payment/service/CartService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/payment/service/CartService.java
@@ -9,6 +9,8 @@ import com.wanted.ailienlmsprogram.member.entity.Member;
 import com.wanted.ailienlmsprogram.payment.dto.CartItemResponse;
 import com.wanted.ailienlmsprogram.payment.entity.Cart;
 import com.wanted.ailienlmsprogram.payment.repository.CartRepository;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,18 +39,17 @@ public class CartService {
     public void addToCart(Long courseId, Member member) {
 
         Course course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 강좌입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강좌입니다."));
 
         if (cartRepository.existsByCourseCourseIdAndMemberMemberId(courseId, member.getMemberId())) {
-            throw new IllegalArgumentException("이미 장바구니에 담긴 강좌입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 장바구니에 담긴 강좌입니다.");
         }
 
-        // '수강 중(COMPLETED)'인 상태의 데이터가 있을 때만 막아야 합니다 예아~~~
         if (enrollmentRepository.existsByMember_LoginIdAndCourse_CourseIdAndStatus(
                 member.getLoginId(),
                 courseId,
                 Enrollment.EnrollmentStatus.ACTIVE)) {
-            throw new IllegalArgumentException("이미 수강 중인 강좌입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 수강 중인 강좌입니다.");
         }
 
         Cart cart = new Cart();
@@ -61,10 +62,10 @@ public class CartService {
     @Transactional
     public void removeFromCart(Long cartId, Member member) {
         Cart cart = cartRepository.findById(cartId)
-                .orElseThrow(() -> new IllegalArgumentException("장바구니 항목이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "장바구니 항목이 존재하지 않습니다."));
 
         if (!cart.getMember().getMemberId().equals(member.getMemberId())) {
-            throw new IllegalArgumentException("본인의 장바구니 항목만 삭제할 수 있습니다.");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인의 장바구니 항목만 삭제할 수 있습니다.");
         }
 
         cartRepository.delete(cart);
@@ -76,19 +77,19 @@ public class CartService {
      */
     public Map<String, Object> prepareTossPayment(List<Long> cartIds, Member member) {
         if (cartIds == null || cartIds.isEmpty()) {
-            throw new IllegalArgumentException("선택된 강좌가 없습니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "선택된 강좌가 없습니다.");
         }
 
         List<Cart> carts = cartRepository.findAllById(cartIds);
 
         if (carts.size() != cartIds.size()) {
-            throw new IllegalArgumentException("존재하지 않는 장바구니 항목이 포함되어 있습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 장바구니 항목이 포함되어 있습니다.");
         }
 
         boolean allBelongToMember = carts.stream()
                 .allMatch(c -> c.getMember().getMemberId().equals(member.getMemberId()));
         if (!allBelongToMember) {
-            throw new IllegalArgumentException("접근 권한이 없는 항목이 포함되어 있습니다.");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "접근 권한이 없는 항목이 포함되어 있습니다.");
         }
 
         int totalAmount = carts.stream().mapToInt(c -> c.getCourse().getCoursePrice()).sum();

--- a/src/main/java/com/wanted/ailienlmsprogram/payment/service/PaymentService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/payment/service/PaymentService.java
@@ -14,6 +14,8 @@ import com.wanted.ailienlmsprogram.payment.repository.CartRepository;
 import com.wanted.ailienlmsprogram.payment.repository.PaymentItemRepository;
 import com.wanted.ailienlmsprogram.payment.repository.PaymentRepository;
 import com.wanted.ailienlmsprogram.payment.repository.RefundRepository;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,7 +44,7 @@ public class PaymentService {
 
     public PaymentDetailResponse getPaymentDetail(Long paymentId, Member member) {
         Payment payment = paymentRepository.findByPaymentIdAndMemberMemberId(paymentId, member.getMemberId())
-                .orElseThrow(() -> new IllegalArgumentException("결제 내역이 존재하지 않거나 접근 권한이 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "결제 내역이 존재하지 않거나 접근 권한이 없습니다."));
 
         return new PaymentDetailResponse(
                 payment,
@@ -55,7 +57,7 @@ public class PaymentService {
     public Payment checkoutAll(Member member) {
         List<Cart> cartItems = cartRepository.findByMemberMemberId(member.getMemberId());
         if (cartItems.isEmpty()) {
-            throw new IllegalArgumentException("장바구니가 비어 있습니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "장바구니가 비어 있습니다.");
         }
         return processCheckout(cartItems, member);
     }
@@ -63,10 +65,10 @@ public class PaymentService {
     @Transactional
     public Payment checkoutSingle(Long cartId, Member member) {
         Cart cart = cartRepository.findById(cartId)
-                .orElseThrow(() -> new IllegalArgumentException("장바구니 항목이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "장바구니 항목이 존재하지 않습니다."));
 
         if (!cart.getMember().getMemberId().equals(member.getMemberId())) {
-            throw new IllegalArgumentException("본인의 장바구니 항목만 결제할 수 있습니다.");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인의 장바구니 항목만 결제할 수 있습니다.");
         }
 
         return processCheckout(List.of(cart), member);
@@ -115,19 +117,19 @@ public class PaymentService {
         // 1. 장바구니 항목 로드 및 소유권 검증
         List<Cart> cartItems = cartRepository.findAllById(cartIds);
         if (cartItems.isEmpty()) {
-            throw new IllegalArgumentException("결제할 강좌를 찾을 수 없습니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "결제할 강좌를 찾을 수 없습니다.");
         }
 
         boolean allBelongToMember = cartItems.stream()
                 .allMatch(c -> c.getMember().getMemberId().equals(member.getMemberId()));
         if (!allBelongToMember) {
-            throw new IllegalArgumentException("접근 권한이 없는 항목이 포함되어 있습니다.");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "접근 권한이 없는 항목이 포함되어 있습니다.");
         }
 
         // 2. 금액 위변조 검증 — DB 기준 가격 합산과 클라이언트 전달 금액 비교
         int expectedAmount = cartItems.stream().mapToInt(c -> c.getCourse().getCoursePrice()).sum();
         if (expectedAmount != (int) amount) {
-            throw new IllegalArgumentException(
+            throw new BusinessException(ErrorCode.BAD_REQUEST,
                     "결제 금액이 일치하지 않습니다. (예상: " + expectedAmount + "원, 수신: " + amount + "원)");
         }
 
@@ -136,16 +138,16 @@ public class PaymentService {
         TossPaymentResponse response = tossPaymentClient.confirm(paymentKey, orderId, amount);
 
         if (response == null) {
-            throw new IllegalArgumentException("토스페이먼츠 응답을 받지 못했습니다.");
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR, "토스페이먼츠 응답을 받지 못했습니다.");
         }
         if (!"DONE".equals(response.getStatus())) {
-            throw new IllegalArgumentException("결제가 완료되지 않았습니다. (status: " + response.getStatus() + ")");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "결제가 완료되지 않았습니다. (status: " + response.getStatus() + ")");
         }
         if (response.getTotalAmount() != expectedAmount) {
-            throw new IllegalArgumentException("Toss 응답 금액이 일치하지 않습니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "Toss 응답 금액이 일치하지 않습니다.");
         }
         if (!response.getOrderId().equals(orderId)) {
-            throw new IllegalArgumentException("Toss 응답 주문번호가 일치하지 않습니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "Toss 응답 주문번호가 일치하지 않습니다.");
         }
 
 
@@ -185,10 +187,10 @@ public class PaymentService {
     @Transactional
     public void requestRefund(Long paymentId, String refundReason, Member member) {
         Payment payment = paymentRepository.findByPaymentIdAndMemberMemberId(paymentId, member.getMemberId())
-                .orElseThrow(() -> new IllegalArgumentException("결제 내역이 존재하지 않거나 접근 권한이 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "결제 내역이 존재하지 않거나 접근 권한이 없습니다."));
 
         if (refundRepository.findByPaymentPaymentId(paymentId).isPresent()) {
-            throw new IllegalArgumentException("이미 환불이 요청되었거나 처리된 결제입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 환불이 요청되었거나 처리된 결제입니다.");
         }
 
         Refund refund = new Refund();

--- a/src/main/java/com/wanted/ailienlmsprogram/qna/service/QnaService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/qna/service/QnaService.java
@@ -7,9 +7,10 @@ import com.wanted.ailienlmsprogram.member.repository.MemberRepository;
 import com.wanted.ailienlmsprogram.qna.dto.*;
 import com.wanted.ailienlmsprogram.qna.entity.Qna;
 import com.wanted.ailienlmsprogram.qna.repository.QnaRepository;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,10 +50,10 @@ public class QnaService {
     public void qnaWrite(Long courseId, Long memberId, QnawriteRequestDTO dto) {
 
         Course course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 강좌가 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 강좌가 존재하지 않습니다."));
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 요원입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 요원입니다."));
 
         Qna qna = Qna.create(dto.getQnaTitle(), dto.getQnaContent(), course, member, null);
         qnaRepository.save(qna);
@@ -63,11 +64,10 @@ public class QnaService {
     public void deleteQna(Long qnaId, Long memberId) {
 
         Qna qna = qnaRepository.findById(qnaId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다. id=" + qnaId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 게시글입니다. id=" + qnaId));
 
-        // 작성자 존재하는지
         if (!qna.getAuthor().getMemberId().equals(memberId)) {
-            throw new AccessDeniedException("본인이 작성한 글만 삭제할 수 있습니다");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인이 작성한 글만 삭제할 수 있습니다");
         }
 
         qna.delete();
@@ -78,10 +78,10 @@ public class QnaService {
     public QnaDetailResponseDTO QnaDetail(Long qnaId) {
        // 질문 가져옴
         Qna qna = qnaRepository.findById(qnaId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다. id=" + qnaId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 게시글입니다. id=" + qnaId));
 
         if (qna.isQnaIsDeleted()) {
-            throw new IllegalArgumentException("삭제된 게시글입니다.");
+            throw new BusinessException(ErrorCode.NOT_FOUND, "삭제된 게시글입니다.");
         }
 
         QnaDetailResponseDTO responseDTO = modelMapper.map(qna, QnaDetailResponseDTO.class);
@@ -112,10 +112,10 @@ public class QnaService {
     public QnaModifyResponseDTO modifyPage(Long qnaId, Long memberId) {
 
         Qna qna = qnaRepository.findById(qnaId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 게시글입니다"));
 
         if(!qna.getAuthor().getMemberId().equals(memberId)) {
-            throw new RuntimeException("수정 권한이 없습니다");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "수정 권한이 없습니다");
         }
 
         QnaModifyResponseDTO responseDTO = modelMapper.map(qna, QnaModifyResponseDTO.class);
@@ -128,10 +128,10 @@ public class QnaService {
     public void modifyQna(Long qnaId, QnaModifyRequestDTO requsetDTO, Long memberId) {
 
         Qna qna = qnaRepository.findById(qnaId)
-                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 게시물입니다"));
+                .orElseThrow(()-> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 게시물입니다"));
 
         if(!qna.getAuthor().getMemberId().equals(memberId)) {
-            throw new RuntimeException("수정 권한이 없습니다!");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "수정 권한이 없습니다");
         }
 
         qna.changeTitleAndContent(requsetDTO.getQnaTitle(), requsetDTO.getQnaContent());
@@ -143,17 +143,16 @@ public class QnaService {
     public void replyWrite(Long courseId, Long memberId, Long parentId, QnawriteRequestDTO dto) {
 
         Course course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 강좌가 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "해당 강좌가 존재하지 않습니다."));
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 요원입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 요원입니다."));
 
         Qna parent = qnaRepository.findById(parentId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 질문입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 질문입니다."));
 
-        // 이미 답변이 있으면 중복 등록 방지
         if (qnaRepository.existsReplyByParentId(parentId)) {
-            throw new IllegalStateException("이미 답변이 등록된 질문입니다.");
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "이미 답변이 등록된 질문입니다.");
         }
 
         Qna reply = Qna.create("REPLY", dto.getQnaContent(), course, member, parent);

--- a/src/main/java/com/wanted/ailienlmsprogram/user/service/UserService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/user/service/UserService.java
@@ -4,6 +4,8 @@ import com.wanted.ailienlmsprogram.user.dto.UserFindDTO;
 import com.wanted.ailienlmsprogram.user.dto.UserEditDTO;
 import com.wanted.ailienlmsprogram.user.entity.User;
 import com.wanted.ailienlmsprogram.user.repository.UserRepository;
+import com.wanted.ailienlmsprogram.global.exception.BusinessException;
+import com.wanted.ailienlmsprogram.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.core.io.Resource;
@@ -26,7 +28,7 @@ public class UserService {
 
     public UserFindDTO findUserById(Long memberId) {
         User user = userRepository.findById(memberId)
-                .orElseThrow(RuntimeException::new);
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
 
         return modelMapper.map(user, UserFindDTO.class);
     }
@@ -35,7 +37,7 @@ public class UserService {
     public void editUserProfile(Long memberId, UserEditDTO request, MultipartFile profileImageFile) throws IOException {
 
         User user = userRepository.findById(memberId)
-                                  .orElseThrow(RuntimeException::new);
+                                  .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 회원입니다."));
 
         // 이미지 처리
         String profileImageUrl;


### PR DESCRIPTION
## 관련 이슈
Closes #173 

## 작업 브랜치
- refactor/exception

## 작업 목적
- 기존에 각자 맘대로 던지던 예외들을 비즈니스 예외로 통일했습니다.

## 변경 사항
- `qna`, `coursecommand`, `coursenotice`, `lecture`, `lectureprogress`, `member`, `community`, `payment`, `admin`, `continent` 패키지
- Service, Repository, Client

## 상세 변경 내용
1. `IllegalArgumentException`, `IllegalStateException`, `RuntimeException`, `AccessDeniedException` → `BusinessException` 전체 교체
2. 존재하지 않는 리소스 → `ErrorCode.NOT_FOUND`
3. 중복/잘못된 상태/비즈니스 규칙 위반 → `ErrorCode.BAD_REQUEST`
4. 권한 없음/소유권 위반 → `ErrorCode.FORBIDDEN`
5. 외부 API 실패 → `ErrorCode.INTERNAL_SERVER_ERROR`
6. 메서드 참조 방식(`IllegalArgumentException::new`, `RuntimeException::new`) → `BusinessException` 교체 (`CourseCommandService`, `UserService`, `ContinentService`)
7. 각 파일에 `BusinessException`, `ErrorCode` import 추가

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

