### PR TITLE
성능 최적화

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/coursecommand/dao/CourseRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursecommand/dao/CourseRepository.java
@@ -20,4 +20,11 @@ public interface CourseRepository extends JpaRepository<Course,Long> {
     List<Course> findByInstructor_MemberIdAndCourseStatus(Long memberId, CourseStatus courseStatus);
 
     boolean existsByCourseIdAndInstructor_MemberId(Long courseId, Long instructorMemberId);
+
+    @Query("select c from Course c " +
+            "join fetch c.instructor " +
+            "where c.instructor.memberId = :memberId " +
+            "and c.courseStatus = :courseStatus")
+    List<Course> findMyCoursesWithInstructor(@Param("memberId") Long memberId,
+                                             @Param("courseStatus") CourseStatus courseStatus);
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/coursecommand/entity/Course.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursecommand/entity/Course.java
@@ -21,11 +21,11 @@ public class Course {
     @Column(name = "course_id")
     private Long courseId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "continent_id", nullable = false)
     private Continent continent;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "instructor_id", nullable = false)
     private User instructor;
 

--- a/src/main/java/com/wanted/ailienlmsprogram/coursecommand/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursecommand/service/CourseCommandService.java
@@ -114,7 +114,12 @@ public class CourseCommandService {
 
     public List<CourseFindDTO> findMyCourses(Long memberId, CourseStatus courseStatus) {
 
-        List<Course> courses = courseRepository.findByInstructor_MemberIdAndCourseStatus(memberId, courseStatus);
+        //List<Course> courses = courseRepository.findByInstructor_MemberIdAndCourseStatus(memberId, courseStatus);
+
+        // fetch join 적용 메서드
+        List<Course> courses = courseRepository.findMyCoursesWithInstructor(memberId, courseStatus);
+
+
 
         return courses.stream()
                 .map(course -> {

--- a/src/main/java/com/wanted/ailienlmsprogram/coursenotice/dao/CourseNoticeRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursenotice/dao/CourseNoticeRepository.java
@@ -2,11 +2,19 @@ package com.wanted.ailienlmsprogram.coursenotice.dao;
 
 import com.wanted.ailienlmsprogram.coursenotice.entity.CourseNotice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CourseNoticeRepository extends JpaRepository<CourseNotice, Long> {
 
     // 특정 강좌의 공지사항 전체 조회 (최신순)
-    List<CourseNotice> findByCourse_CourseIdOrderByCreatedAtDesc(Long courseId);
+    //List<CourseNotice> findByCourse_CourseIdOrderByCreatedAtDesc(Long courseId);
+
+    @Query("select cn from CourseNotice cn " +
+            "join fetch cn.course " +
+            "where cn.course.courseId = :courseId " +
+            "order by cn.createdAt desc")
+    List<CourseNotice> findByCourseIdWithFetchJoin(@Param("courseId") Long courseId);
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/coursenotice/entity/CourseNotice.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursenotice/entity/CourseNotice.java
@@ -21,11 +21,11 @@ public class CourseNotice {
     @Column(name = "notice_id")
     private Long noticeId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id")
     private Course course;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id")
     private Member author;
 

--- a/src/main/java/com/wanted/ailienlmsprogram/coursenotice/service/CourseNoticeService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursenotice/service/CourseNoticeService.java
@@ -51,7 +51,7 @@ public class CourseNoticeService {
         }
 
         List<CourseNotice> notices = courseNoticeRepository
-                .findByCourse_CourseIdOrderByCreatedAtDesc(courseId);
+                .findByCourseIdWithFetchJoin(courseId);
 
         return notices.stream()
                 .map(notice -> {

--- a/src/main/java/com/wanted/ailienlmsprogram/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/enrollment/repository/EnrollmentRepository.java
@@ -14,9 +14,12 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     Optional<Enrollment> findByMemberMemberIdAndCourseCourseId(Long memberId, Long courseId);
 
-    @Query(value = "SELECT e FROM Enrollment e WHERE e.member.memberId = :memberId AND e.status = 'ACTIVE'")
-    List<Enrollment> findAllByMember_MemberId(@Param("memberId") Long studentId);
-
+    @Query("SELECT e FROM Enrollment e " +
+            "JOIN FETCH e.course c " +          // 강좌 정보를 조인해서 가져오고
+            "LEFT JOIN FETCH c.instructor i " + // 강좌의 강사 정보까지 조인해서 가져옴
+            "WHERE e.member.memberId = :memberId " +
+            "AND e.status = 'ACTIVE'")
+    List<Enrollment> findAllByMemberWithCourseAndInstructor(@Param("memberId") Long studentId);
 
     boolean existsByMember_LoginIdAndCourse_CourseIdAndStatus(String memberLoginId, Long courseCourseId, Enrollment.EnrollmentStatus status);
 

--- a/src/main/java/com/wanted/ailienlmsprogram/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/enrollment/service/EnrollmentService.java
@@ -57,7 +57,7 @@ public class EnrollmentService {
 
     // 내가 수강 중인 강좌 조회
     public List<EnrollmentResponseDTO> enrollmentsByMemberId(Long studentId) {
-        List<Enrollment> enrollmentList = enrollmentRepository.findAllByMember_MemberId(studentId);
+        List<Enrollment> enrollmentList = enrollmentRepository.findAllByMemberWithCourseAndInstructor(studentId);
 
         return enrollmentList.stream()
                 .map(enrollment -> {

--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/dao/LectureRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/dao/LectureRepository.java
@@ -1,13 +1,20 @@
 package com.wanted.ailienlmsprogram.lecture.dao;
 
-import com.wanted.ailienlmsprogram.coursecommand.entity.Course;
+
 import com.wanted.ailienlmsprogram.lecture.entity.Lecture;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface LectureRepository extends JpaRepository<Lecture,Long> {
-    List<Lecture> findByCourse_CourseId(Long courseId);
+    //List<Lecture> findByCourse_CourseId(Long courseId);
+
+    @Query("select l from lecture l " +
+            "join fetch l.course " +
+            "where l.course.courseId = :courseId")
+    List<Lecture> findByCourseIdWithFetchJoin(@Param("courseId") Long courseId);
 
     List<Lecture> findAllByCourse_CourseId(Long courseId);
     int countByCourse_CourseId(Long courseId);

--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/entity/Lecture.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/entity/Lecture.java
@@ -19,7 +19,7 @@ public class Lecture {
     @Column(name = "lecture_id")
     private Long lectureId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id", nullable = false)
     private Course course;
 

--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/service/LectureService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/service/LectureService.java
@@ -32,7 +32,7 @@ public class LectureService {
 
     public List<LectureFindDTO> findMyLectures(Long courseId) {
 
-        List<Lecture> lectures = lectureRepository.findByCourse_CourseId(courseId);
+        List<Lecture> lectures = lectureRepository.findByCourseIdWithFetchJoin(courseId);
 
         return lectures.stream()
                 .map(lecture -> modelMapper.map(lecture, LectureFindDTO.class))
@@ -65,7 +65,7 @@ public class LectureService {
     // 강좌 상세 입장 시 뜨는 강의 목록
     public List<LectureResponseDTO> lectureByCourse(Long courseId) {
 
-        List<Lecture> foundLectures = lectureRepository.findByCourse_CourseId(courseId);
+        List<Lecture> foundLectures = lectureRepository.findByCourseIdWithFetchJoin(courseId);
 
         return foundLectures.stream()
                 .map(lecture -> modelMapper.map(lecture, LectureResponseDTO.class))

--- a/src/main/java/com/wanted/ailienlmsprogram/qna/repository/QnaRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/qna/repository/QnaRepository.java
@@ -10,7 +10,16 @@ import java.util.List;
 
 public interface QnaRepository extends JpaRepository<Qna, Long> {
 
-    List<Qna> findAllByCourse_CourseIdAndParentIsNullAndQnaIsDeletedFalse(Long courseId);
+    //List<Qna> findAllByCourse_CourseIdAndParentIsNullAndQnaIsDeletedFalse(Long courseId);
+
+    @Query("select q, " +
+            "(select count(r) > 0 from Qna r where r.parent = q and r.qnaIsDeleted = false) " +
+            "from Qna q " +
+            "join fetch q.author " + // 작성자 한 방에 가져오기 (Fetch Join)
+            "where q.course.courseId = :courseId " +
+            "and q.parent is null " +
+            "and q.qnaIsDeleted = false")
+    List<Object[]> findAllByCourseIdWithAuthorAndReplyStatus(@Param("courseId") Long courseId);
 
     List<Qna> findAllByParent_QnaIdAndQnaIsDeletedFalse(Long qnaId);
 

--- a/src/main/java/com/wanted/ailienlmsprogram/qna/service/QnaService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/qna/service/QnaService.java
@@ -27,14 +27,17 @@ public class QnaService {
     private  final MemberRepository memberRepository;
 
     public List<QnaResponseDTO> questionByCourse(Long courseId, String status) {
+        // 1. 쿼리 단 1번 실행 (작성자 + 답변여부 포함)
+        List<Object[]> results = qnaRepository.findAllByCourseIdWithAuthorAndReplyStatus(courseId);
 
-        List<Qna> qnaList = qnaRepository.findAllByCourse_CourseIdAndParentIsNullAndQnaIsDeletedFalse(courseId);
+        return results.stream()
+                .map(result -> {
+                    Qna qna = (Qna) result[0];
+                    boolean isAnswered = (boolean) result[1]; // 서브쿼리 결과값 (true/false)
 
-        return qnaList.stream()
-                .map(qna -> {
                     QnaResponseDTO dto = modelMapper.map(qna, QnaResponseDTO.class);
-                    dto.setAuthorName(qna.getAuthor().getName());
-                    dto.setAnswered(qnaRepository.existsReplyByParentId(qna.getQnaId()));
+                    dto.setAuthorName(qna.getAuthor().getName()); // Fetch Join으로 이미 로딩됨
+                    dto.setAnswered(isAnswered); // 추가 쿼리 없이 바로 셋팅!
                     return dto;
                 })
                 .filter(dto -> {

--- a/src/main/resources/ddl/dummy.sql
+++ b/src/main/resources/ddl/dummy.sql
@@ -1,0 +1,234 @@
+USE module02_lms;
+SET FOREIGN_KEY_CHECKS = 0;
+
+-- =============================================
+-- 기존 데이터 초기화 (FK 순서: 자식 → 부모)
+-- =============================================
+TRUNCATE TABLE REFUND;
+TRUNCATE TABLE PAYMENT_ITEM;
+TRUNCATE TABLE PAYMENT;
+TRUNCATE TABLE CART;
+TRUNCATE TABLE REPORT;
+TRUNCATE TABLE LECTURE_PROGRESS;
+TRUNCATE TABLE QNA;
+TRUNCATE TABLE ENROLLMENT;
+TRUNCATE TABLE COURSE_NOTICE;
+TRUNCATE TABLE CONTINENT_COMMENT;
+TRUNCATE TABLE CONTINENT_POST;
+TRUNCATE TABLE LECTURE;
+TRUNCATE TABLE COURSE;
+TRUNCATE TABLE CONTINENT;
+TRUNCATE TABLE MEMBER;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+-- =============================================
+-- MEMBER (강사 10명: ID 1~10, 학생 20명: ID 11~30)
+-- 비밀번호: 1234
+-- =============================================
+INSERT INTO MEMBER (login_id, email, password, member_name, phone, member_role, member_status, member_rank, created_at, updated_at) VALUES
+('instructor01', 'instructor01@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '강사김우주', '010-1111-0001', 'INSTRUCTOR', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('instructor02', 'instructor02@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '강사이외계', '010-1111-0002', 'INSTRUCTOR', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('instructor03', 'instructor03@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '강사박행성', '010-1111-0003', 'INSTRUCTOR', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('instructor04', 'instructor04@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '강사최은하', '010-1111-0004', 'INSTRUCTOR', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('instructor05', 'instructor05@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '강사정성운', '010-1111-0005', 'INSTRUCTOR', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('instructor06', 'instructor06@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '강사한혜성', '010-1111-0006', 'INSTRUCTOR', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('instructor07', 'instructor07@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '강사오성층', '010-1111-0007', 'INSTRUCTOR', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('instructor08', 'instructor08@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '강사서대기', '010-1111-0008', 'INSTRUCTOR', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('instructor09', 'instructor09@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '강사남궤도', '010-1111-0009', 'INSTRUCTOR', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('instructor10', 'instructor10@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '강사류소행', '010-1111-0010', 'INSTRUCTOR', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('student01', 'student01@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생001', '010-2222-0001', 'STUDENT', 'ACTIVE', 'NOVICE', NOW(), NOW()),
+('student02', 'student02@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생002', '010-2222-0002', 'STUDENT', 'ACTIVE', 'NOVICE', NOW(), NOW()),
+('student03', 'student03@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생003', '010-2222-0003', 'STUDENT', 'ACTIVE', 'MINERVAL', NOW(), NOW()),
+('student04', 'student04@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생004', '010-2222-0004', 'STUDENT', 'ACTIVE', 'MINERVAL', NOW(), NOW()),
+('student05', 'student05@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생005', '010-2222-0005', 'STUDENT', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('student06', 'student06@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생006', '010-2222-0006', 'STUDENT', 'ACTIVE', 'NOVICE', NOW(), NOW()),
+('student07', 'student07@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생007', '010-2222-0007', 'STUDENT', 'ACTIVE', 'NOVICE', NOW(), NOW()),
+('student08', 'student08@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생008', '010-2222-0008', 'STUDENT', 'ACTIVE', 'MINERVAL', NOW(), NOW()),
+('student09', 'student09@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생009', '010-2222-0009', 'STUDENT', 'ACTIVE', 'MINERVAL', NOW(), NOW()),
+('student10', 'student10@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생010', '010-2222-0010', 'STUDENT', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('student11', 'student11@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생011', '010-2222-0011', 'STUDENT', 'ACTIVE', 'NOVICE', NOW(), NOW()),
+('student12', 'student12@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생012', '010-2222-0012', 'STUDENT', 'ACTIVE', 'NOVICE', NOW(), NOW()),
+('student13', 'student13@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생013', '010-2222-0013', 'STUDENT', 'ACTIVE', 'MINERVAL', NOW(), NOW()),
+('student14', 'student14@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생014', '010-2222-0014', 'STUDENT', 'ACTIVE', 'MINERVAL', NOW(), NOW()),
+('student15', 'student15@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생015', '010-2222-0015', 'STUDENT', 'ACTIVE', 'REPTILIAN', NOW(), NOW()),
+('student16', 'student16@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생016', '010-2222-0016', 'STUDENT', 'ACTIVE', 'NOVICE', NOW(), NOW()),
+('student17', 'student17@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생017', '010-2222-0017', 'STUDENT', 'ACTIVE', 'NOVICE', NOW(), NOW()),
+('student18', 'student18@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생018', '010-2222-0018', 'STUDENT', 'ACTIVE', 'MINERVAL', NOW(), NOW()),
+('student19', 'student19@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생019', '010-2222-0019', 'STUDENT', 'ACTIVE', 'MINERVAL', NOW(), NOW()),
+('student20', 'student20@test.com', '$2a$10$Q4O6rm5aFLDT4VzpxHRu8uQZD4aEU3FTeQftGqJQnftcUpIWfTnSm', '학생020', '010-2222-0020', 'STUDENT', 'ACTIVE', 'REPTILIAN', NOW(), NOW());
+
+-- =============================================
+-- CONTINENT (10개)
+-- =============================================
+INSERT INTO CONTINENT (continent_name, continent_description) VALUES
+('알파 센타우리', '가장 가까운 항성계 기반 강좌 모음'),
+('오리온 성운', '성운 탐험 및 우주 항법 강좌'),
+('안드로메다', '은하 간 이동 기술 강좌'),
+('마젤란 성운', '위성 은하 탐사 전문 강좌'),
+('시리우스', '밝은 별 기반 에너지 강좌'),
+('베텔게우스', '초거성 생존 전략 강좌'),
+('플레이아데스', '성단 항법 기술 강좌'),
+('카시오페이아', '항성 좌표 탐색 강좌'),
+('용골자리', '거대 성운 탐험 강좌'),
+('삼각형자리', '삼각 은하 기반 과학 강좌');
+
+-- =============================================
+-- COURSE (강사당 5개씩, 총 50개)
+-- instructor01(ID=1) ~ instructor10(ID=10)
+-- =============================================
+INSERT INTO COURSE (continent_id, instructor_id, course_title, course_description, course_price, course_status, created_at) VALUES
+-- instructor01 (5개)
+(1, 1, '우주 항법 기초 A', '알파 센타우리 항법 기초 강좌입니다.', 50000, 'PUBLISHED', NOW()),
+(2, 1, '우주 항법 기초 B', '오리온 성운 항법 기초 강좌입니다.', 55000, 'PUBLISHED', NOW()),
+(3, 1, '우주 항법 기초 C', '안드로메다 항법 기초 강좌입니다.', 60000, 'PUBLISHED', NOW()),
+(4, 1, '우주 항법 기초 D', '마젤란 항법 기초 강좌입니다.', 65000, 'PUBLISHED', NOW()),
+(5, 1, '우주 항법 기초 E', '시리우스 항법 기초 강좌입니다.', 70000, 'PUBLISHED', NOW()),
+-- instructor02 (5개)
+(1, 2, '성운 생존 전략 A', '알파 센타우리 생존 전략입니다.', 50000, 'PUBLISHED', NOW()),
+(2, 2, '성운 생존 전략 B', '오리온 성운 생존 전략입니다.', 55000, 'PUBLISHED', NOW()),
+(3, 2, '성운 생존 전략 C', '안드로메다 생존 전략입니다.', 60000, 'PUBLISHED', NOW()),
+(4, 2, '성운 생존 전략 D', '마젤란 생존 전략입니다.', 65000, 'PUBLISHED', NOW()),
+(5, 2, '성운 생존 전략 E', '시리우스 생존 전략입니다.', 70000, 'PUBLISHED', NOW()),
+-- instructor03 (5개)
+(6, 3, '은하 이동술 A', '베텔게우스 이동술 강좌입니다.', 80000, 'PUBLISHED', NOW()),
+(7, 3, '은하 이동술 B', '플레이아데스 이동술 강좌입니다.', 85000, 'PUBLISHED', NOW()),
+(8, 3, '은하 이동술 C', '카시오페이아 이동술 강좌입니다.', 90000, 'PUBLISHED', NOW()),
+(9, 3, '은하 이동술 D', '용골자리 이동술 강좌입니다.', 95000, 'PUBLISHED', NOW()),
+(10, 3, '은하 이동술 E', '삼각형자리 이동술 강좌입니다.', 100000, 'PUBLISHED', NOW()),
+-- instructor04 (5개)
+(1, 4, '에너지학 기초 A', '알파 센타우리 에너지학입니다.', 45000, 'PUBLISHED', NOW()),
+(2, 4, '에너지학 기초 B', '오리온 에너지학입니다.', 50000, 'PUBLISHED', NOW()),
+(3, 4, '에너지학 기초 C', '안드로메다 에너지학입니다.', 55000, 'PUBLISHED', NOW()),
+(4, 4, '에너지학 기초 D', '마젤란 에너지학입니다.', 60000, 'PUBLISHED', NOW()),
+(5, 4, '에너지학 기초 E', '시리우스 에너지학입니다.', 65000, 'PUBLISHED', NOW()),
+-- instructor05 (5개)
+(6, 5, '초거성 탐험 A', '베텔게우스 탐험 강좌입니다.', 75000, 'PUBLISHED', NOW()),
+(7, 5, '초거성 탐험 B', '플레이아데스 탐험 강좌입니다.', 80000, 'PUBLISHED', NOW()),
+(8, 5, '초거성 탐험 C', '카시오페이아 탐험 강좌입니다.', 85000, 'PUBLISHED', NOW()),
+(9, 5, '초거성 탐험 D', '용골자리 탐험 강좌입니다.', 90000, 'PUBLISHED', NOW()),
+(10, 5, '초거성 탐험 E', '삼각형자리 탐험 강좌입니다.', 95000, 'PUBLISHED', NOW()),
+-- instructor06 (5개)
+(1, 6, '항성 좌표 A', '알파 센타우리 좌표 강좌입니다.', 55000, 'PUBLISHED', NOW()),
+(2, 6, '항성 좌표 B', '오리온 좌표 강좌입니다.', 60000, 'PUBLISHED', NOW()),
+(3, 6, '항성 좌표 C', '안드로메다 좌표 강좌입니다.', 65000, 'PUBLISHED', NOW()),
+(4, 6, '항성 좌표 D', '마젤란 좌표 강좌입니다.', 70000, 'PUBLISHED', NOW()),
+(5, 6, '항성 좌표 E', '시리우스 좌표 강좌입니다.', 75000, 'PUBLISHED', NOW()),
+-- instructor07 (5개)
+(6, 7, '성단 항법 A', '베텔게우스 항법 강좌입니다.', 60000, 'PUBLISHED', NOW()),
+(7, 7, '성단 항법 B', '플레이아데스 항법 강좌입니다.', 65000, 'PUBLISHED', NOW()),
+(8, 7, '성단 항법 C', '카시오페이아 항법 강좌입니다.', 70000, 'PUBLISHED', NOW()),
+(9, 7, '성단 항법 D', '용골자리 항법 강좌입니다.', 75000, 'PUBLISHED', NOW()),
+(10, 7, '성단 항법 E', '삼각형자리 항법 강좌입니다.', 80000, 'PUBLISHED', NOW()),
+-- instructor08 (5개)
+(1, 8, '은하 과학 A', '알파 센타우리 과학 강좌입니다.', 85000, 'PUBLISHED', NOW()),
+(2, 8, '은하 과학 B', '오리온 과학 강좌입니다.', 90000, 'PUBLISHED', NOW()),
+(3, 8, '은하 과학 C', '안드로메다 과학 강좌입니다.', 95000, 'PUBLISHED', NOW()),
+(4, 8, '은하 과학 D', '마젤란 과학 강좌입니다.', 100000, 'PUBLISHED', NOW()),
+(5, 8, '은하 과학 E', '시리우스 과학 강좌입니다.', 50000, 'PUBLISHED', NOW()),
+-- instructor09 (5개)
+(6, 9, '우주 물리 A', '베텔게우스 물리 강좌입니다.', 70000, 'PUBLISHED', NOW()),
+(7, 9, '우주 물리 B', '플레이아데스 물리 강좌입니다.', 75000, 'PUBLISHED', NOW()),
+(8, 9, '우주 물리 C', '카시오페이아 물리 강좌입니다.', 80000, 'PUBLISHED', NOW()),
+(9, 9, '우주 물리 D', '용골자리 물리 강좌입니다.', 85000, 'PUBLISHED', NOW()),
+(10, 9, '우주 물리 E', '삼각형자리 물리 강좌입니다.', 90000, 'PUBLISHED', NOW()),
+-- instructor10 (5개)
+(1, 10, '항성 진화 A', '알파 센타우리 진화 강좌입니다.', 55000, 'PUBLISHED', NOW()),
+(2, 10, '항성 진화 B', '오리온 진화 강좌입니다.', 60000, 'PUBLISHED', NOW()),
+(3, 10, '항성 진화 C', '안드로메다 진화 강좌입니다.', 65000, 'PUBLISHED', NOW()),
+(4, 10, '항성 진화 D', '마젤란 진화 강좌입니다.', 70000, 'PUBLISHED', NOW()),
+(5, 10, '항성 진화 E', '시리우스 진화 강좌입니다.', 75000, 'PUBLISHED', NOW());
+
+-- =============================================
+-- LECTURE (강좌당 10개씩, 총 500개)
+-- 공개 샘플 영상 URL 사용
+-- =============================================
+-- course 1~10 (강좌 1~10 각 10강)
+INSERT INTO LECTURE (course_id, lecture_title, lecture_description, lecture_order_index, video_url, created_at)
+SELECT
+    c.course_id,
+    CONCAT(c.course_title, ' ', n.n, '강'),
+    CONCAT(n.n, '번째 강의입니다.'),
+    n.n,
+    ELT(1 + (n.n % 9),
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4',
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4',
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4',
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4',
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/ForBiggerMeltdowns.mp4',
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/Sintel.mp4',
+        'https://storage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4'
+    ),
+    NOW()
+FROM COURSE c
+CROSS JOIN (
+    SELECT 1 AS n UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5
+    UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9 UNION SELECT 10
+) n;
+
+-- =============================================
+-- COURSE_NOTICE (강좌당 5개씩, 총 250개)
+-- =============================================
+INSERT INTO COURSE_NOTICE (course_id, author_id, notice_title, notice_content, created_at, updated_at)
+SELECT
+    c.course_id,
+    c.instructor_id,
+    CONCAT(c.course_title, ' 공지사항 ', n.n),
+    CONCAT(n.n, '번째 공지입니다. 수강생 여러분 확인 부탁드립니다.'),
+    NOW(),
+    NOW()
+FROM COURSE c
+CROSS JOIN (
+    SELECT 1 AS n UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5
+) n;
+
+-- =============================================
+-- ENROLLMENT (학생당 10개씩, 총 200개)
+-- 학생 ID 11~30, 강좌 ID 1~50 순환
+-- =============================================
+INSERT INTO ENROLLMENT (member_id, course_id, enrollment_status, created_at, enrollment_progress_rate)
+SELECT
+    m.member_id,
+    ((m.member_id - 11) * 10 + n.n) AS course_id,
+    'ACTIVE',
+    NOW(),
+    ROUND(RAND() * 100, 2)
+FROM MEMBER m
+CROSS JOIN (
+    SELECT 1 AS n UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5
+    UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9 UNION SELECT 10
+) n
+WHERE m.member_role = 'STUDENT'
+  AND ((m.member_id - 11) * 10 + n.n) BETWEEN 1 AND 50;
+
+-- =============================================
+-- LECTURE_PROGRESS (수강생별 첫 5강 완료, 총 약 500개)
+-- =============================================
+INSERT INTO LECTURE_PROGRESS (member_id, lecture_id, progress_is_completed)
+SELECT DISTINCT
+    e.member_id,
+    l.lecture_id,
+    TRUE
+FROM ENROLLMENT e
+JOIN LECTURE l ON l.course_id = e.course_id
+WHERE l.lecture_order_index <= 5;
+
+-- =============================================
+-- QNA (강좌당 10개씩, 총 500개)
+-- Entity 기준 course_id FK 사용
+-- =============================================
+INSERT INTO QNA (course_id, author_id, qna_title, qna_content, qna_is_deleted, created_at)
+SELECT
+    c.course_id,
+    11 + (c.course_id % 20),
+    CONCAT(c.course_title, ' 질문 ', n.n),
+    CONCAT(c.course_title, '에 대한 ', n.n, '번째 질문입니다.'),
+    FALSE,
+    NOW()
+FROM COURSE c
+CROSS JOIN (
+    SELECT 1 AS n UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5
+    UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9 UNION SELECT 10
+) n;


### PR DESCRIPTION
## 관련 이슈
Closes #200 

## 작업 브랜치
- refactor/optimization

## 작업 목적
- 성능 최적화

## 변경 사항
- `domain/enrollment`, `domain/qna`, `domain/course`, `domain/lecture` 패키지
- Controller / Service / Repository 전반

### 상세 변경 내용

1. **JPA Query Optimization (N+1 문제 해결)**
   - 목록 조회 시 연관 엔티티를 한꺼번에 조회하지 않아 발생하는 N+1 문제를 `Fetch Join`과 `Subquery`로 해결했습니다.
   - 대상 기능: 강사 내 강좌 조회, 강의 조회(목록), 공지사항 목록, Qna 목록, 수강 목록

2. **목록 조회 성능 개선 (Fetch Join & Scalar Subquery)**
   - **Fetch Join 적용**: `Enrollment`, `Course`, `Member` 등 연관 관계가 깊은 엔티티들을 단일 쿼리로 묶어 쿼리 수를 평균 21개에서 **1개**로 단축했습니다.
   - **Subquery 활용**: Qna 목록에서 답변의 전체 내용을 가져오는 대신, 답변 여부(Count)만 SELECT 절 서브쿼리로 조회하여 메모리 효율을 높였습니다.

3. **로딩 전략 최적화 (Lazy Loading 전략 고수)**
   - `Eager Loading`의 위험성(불필요한 조인 및 성능 저하)을 방지하기 위해 전역적으로 `Lazy Loading`을 유지했습니다.
   - 성능이 필요한 특정 API(목록 조회 등)에서만 선택적으로 최적화 쿼리를 적용하는 전략을 취했습니다.

4. **단건 처리 및 CUD 로직 경량화**
   - 강의 시청(단건 조회) 및 등록/수정/삭제 로직은 추가적인 Join 없이 가벼운 단일 쿼리(`Lazy`)를 유지하여 DB 부하를 최소화했습니다.
   
## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

