### PR TITLE
게시글 수정시에도 비속어 filtering 적용, 사용자 계급 표시

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/community/controller/PostController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/controller/PostController.java
@@ -1,6 +1,6 @@
 package com.wanted.ailienlmsprogram.community.controller;
 
-import com.wanted.ailienlmsprogram.community.dto.CommentRequestDTO; // 1. 댓글 요청 DTO 임포트 추가
+import com.wanted.ailienlmsprogram.community.dto.CommentRequestDTO;
 import com.wanted.ailienlmsprogram.community.dto.PostCreateRequestDTO;
 import com.wanted.ailienlmsprogram.community.dto.PostDTO;
 import com.wanted.ailienlmsprogram.community.dto.CommentResponseDTO;
@@ -18,7 +18,9 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -36,7 +38,7 @@ public class PostController {
         return "community/posts";
     }
 
-    // 상세 페이지 이동 (수정됨)
+    // 상세 페이지 이동
     @GetMapping("/posts/{postId}")
     public String findPostDetail(@PathVariable Long postId,
                                  Model model,
@@ -48,8 +50,6 @@ public class PostController {
         List<CommentResponseDTO> comments = commentService.findComments(postId);
         model.addAttribute("comments", comments);
 
-        // ★ 핵심: 상세 페이지를 처음 열 때 빈 댓글 DTO를 모델에 담아줍니다.
-        // 이래야 html의 th:object="${commentRequestDTO}" 가 에러 없이 작동합니다.
         model.addAttribute("commentRequestDTO", new CommentRequestDTO());
 
         if (userDetails != null) {
@@ -98,7 +98,7 @@ public class PostController {
         return "community/post_update";
     }
 
-    // 수정 처리
+    // ★ 수정 처리 (보완 완료) ★
     @PostMapping("/continents/posts/edit/{postId}")
     public String updatePost(@PathVariable Long postId,
                              @ModelAttribute PostCreateRequestDTO request,
@@ -108,9 +108,19 @@ public class PostController {
             return "redirect:/posts/" + postId;
 
         } catch (BadWordDetectedException e) {
-            model.addAttribute("postId", postId);
-            model.addAttribute("post", request);
+            // 1. 에러 메시지 전달
             model.addAttribute("errorMessage", e.getMessage());
+            model.addAttribute("postId", postId);
+
+            // 2. 핵심 방어 로직: HTML은 ${post.title}을 원하고, DTO는 postTitle을 가지고 있음.
+            // 이름을 맞춰주기 위해 Map을 생성해 "post"라는 이름으로 던져줍니다.
+            Map<String, Object> errorPost = new HashMap<>();
+            errorPost.put("postId", postId);
+            errorPost.put("title", request.getPostTitle());   // postTitle -> title 로 매핑
+            errorPost.put("content", request.getPostContent()); // postContent -> content 로 매핑
+
+            model.addAttribute("post", errorPost);
+
             return "community/post_update";
         }
     }

--- a/src/main/java/com/wanted/ailienlmsprogram/community/dto/CommentResponseDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/dto/CommentResponseDTO.java
@@ -13,5 +13,6 @@ public class CommentResponseDTO {
     private Long commentId;
     private String content;
     private String memberName; // 작성자 이름
-    private Long memberId;     // 본인 확인용 ID
+    private Long memberId;// 본인 확인용 ID
+
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/community/dto/PostDTO.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/dto/PostDTO.java
@@ -1,6 +1,7 @@
 package com.wanted.ailienlmsprogram.community.dto;
 
 import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
+import com.wanted.ailienlmsprogram.member.entity.Member;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,13 +13,17 @@ import java.time.format.DateTimeFormatter;
 public class PostDTO {
     private Long postId;
     private Long continentId;
-    private String continentName; // 대륙 이름 필드
+    private String continentName;
     private String title;
     private String content;
     private String authorName;
     private String memberId;
     private boolean postIsNotice;
     private String createdAt;
+
+
+    private String authorRank;
+    private String authorRankComment;
 
     public PostDTO(CommunityPost post) {
         this.postId = post.getPostId();
@@ -27,7 +32,7 @@ public class PostDTO {
         this.content = post.getPostContent();
         this.postIsNotice = post.isPostIsNotice();
 
-        // ★ 대륙 번호를 이름으로 변환 (프로젝트 설정에 맞게 수정하세요!)
+        // 대륙 번호를 이름으로 변환
         if (this.continentId != null) {
             switch (this.continentId.intValue()) {
                 case 1: this.continentName = "Java Continent"; break;
@@ -41,10 +46,30 @@ public class PostDTO {
             this.createdAt = post.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         }
 
-        // 작성자 정보 매핑
+        // 작성자 정보 및 등급/멘트 매핑
         if (post.getMember() != null) {
-            this.authorName = post.getMember().getName();
-            this.memberId = String.valueOf(post.getMember().getMemberId());
+            Member member = post.getMember();
+            this.authorName = member.getName();
+            this.memberId = String.valueOf(member.getMemberId());
+
+            // 멤버 엔티티의 Rank 정보를 DTO 필드에 담아줍니다.
+            if (member.getRank() != null) {
+                // 1. 영문 등급명 저장 (HTML의 조건문에서 사용)
+                this.authorRank = member.getRank().name();
+
+                // 2. 한글 멘트 매핑 (화면에 출력)
+                switch (member.getRank()) {
+                    case REPTILIAN:
+                        this.authorRankComment = "왕족 렙틸리언";
+                        break;
+                    case MINERVAL:
+                        this.authorRankComment = "곧 노비스입니다";
+                        break;
+                    case NOVICE:
+                        this.authorRankComment = "저는 게으른 노비스입니다";
+                        break;
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/community/entity/CommunityComment.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/entity/CommunityComment.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 //@Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "continent_comment") // 1. 테이블 이름 연결
+@Table(name = "continent_comment")
 public class CommunityComment {
 
     @Id
@@ -20,7 +20,7 @@ public class CommunityComment {
     @Column(name = "comment_id")
     private Long commentId;
 
-    @Column(name = "comment_content", columnDefinition = "TEXT", nullable = false) // 2. 컬럼 이름 연결
+    @Column(name = "comment_content", columnDefinition = "TEXT", nullable = false)
     private String content;
 
     @Column(name = "comment_is_deleted")
@@ -30,7 +30,7 @@ public class CommunityComment {
     private CommunityPost post;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "author_id") // 3. 작성자 ID 컬럼 연결
+    @JoinColumn(name = "author_id")
     private Member member;
 
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/wanted/ailienlmsprogram/community/service/CommentService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/service/CommentService.java
@@ -24,9 +24,9 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
 
-    // 댓글 쓰기 (DTO를 사용하도록 수정)
+
     @Transactional
-    @BadWordCheck // ★ AOP가 DTO 내부의 content 필드를 감시합니다.
+    @BadWordCheck
     public void saveComment(Long postId, CommentRequestDTO request, Member member) { // 2. String 대신 DTO로 변경
         CommunityPost post = postRepository.findById(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "게시글이 없습니다."));
@@ -39,7 +39,7 @@ public class CommentService {
         commentRepository.save(comment);
     }
 
-    // 댓글 목록 조회 (기존 유지)
+    // 댓글 목록 조회
     public List<CommentResponseDTO> findComments(Long postId) {
         return commentRepository.findByPostPostIdAndIsDeletedFalse(postId).stream()
                 .map(comment -> CommentResponseDTO.builder()
@@ -51,7 +51,7 @@ public class CommentService {
                 .collect(Collectors.toList());
     }
 
-    // 댓글 삭제 (기존 유지)
+    // 댓글 삭제
     @Transactional
     public void deleteComment(Long commentId, Member loginMember) {
         CommunityComment comment = commentRepository.findById(commentId)

--- a/src/main/resources/templates/community/post_detail.html
+++ b/src/main/resources/templates/community/post_detail.html
@@ -16,17 +16,7 @@
         .btn-list { background: #1d295f; }
         .btn-delete { background: #ff5f5f; }
         .btn-report { background: #4b5563; }
-
-        /* 비속어 경고창 스타일 */
-        .error-box {
-            margin-bottom: 20px;
-            padding: 12px 16px;
-            background: #2a1212;
-            border: 1px solid #ff6b6b;
-            color: #ffb4b4;
-            border-radius: 6px;
-            font-size: 14px;
-        }
+        .error-box { margin-bottom: 20px; padding: 12px 16px; background: #2a1212; border: 1px solid #ff6b6b; color: #ffb4b4; border-radius: 6px; font-size: 14px; }
     </style>
 </head>
 <body>
@@ -35,35 +25,37 @@
         <div class="post-header">
             <h1 class="post-title" th:text="${post.title}">제목</h1>
             <div class="post-info">
-                작성자: <span th:text="${post.authorName}">홍길동</span> |
-                대륙: <span th:text="${post.continentName}">Java Continent</span>
+                작성자: <span th:text="${post.authorName}">홍길동</span>
+                <span th:if="${post.authorRankComment}"
+                      th:text="'(' + ${post.authorRankComment} + ')'"
+                      th:style="${post.authorRank == 'REPTILIAN'}
+                                ? 'color: #FFD700; font-weight: bold; text-shadow: 0 0 10px rgba(255, 215, 0, 0.8); font-size: 13px; margin-left: 5px;'
+                                : (${post.authorRank == 'NOVICE'}
+                                   ? 'color: #708090; font-style: italic; font-size: 12px; margin-left: 5px;'
+                                   : 'color: #b8c1e7; font-size: 13px; margin-left: 5px;')"></span>
+                | 대륙: <span th:text="${post.continentName}">Java Continent</span>
             </div>
         </div>
         <div class="post-content" th:text="${post.content}">내용</div>
     </div>
-
     <div class="btn-area">
         <a th:href="@{/continents/{id}/posts(id=${post.continentId})}" class="btn btn-list">목록으로</a>
-
         <th:block th:if="${currentUserId != null and currentUserId == post.memberId}">
             <a th:href="@{/continents/posts/edit/{id}(id=${post.postId})}" class="btn">수정하기</a>
             <form th:action="@{/posts/delete/{id}(id=${post.postId})}" method="post" onsubmit="return confirm('진짜 삭제하시겠습니까?');" style="margin: 0;">
                 <button type="submit" class="btn btn-delete">삭제하기</button>
             </form>
         </th:block>
-
         <button th:if="${currentUserId != null and currentUserId != post.memberId}"
                 type="button" class="btn btn-report"
                 th:onclick="openReportModal('CONTINENT_POST', [[${post.postId}]])">신고하기</button>
     </div>
 </div>
-
 <div class="container" th:if="${!post.postIsNotice}" style="margin-top: 50px; border-top: 1px solid #3d4450; padding-top: 30px;">
     <h3 style="color: #7ee0ff; margin-bottom: 20px;">💬 댓글</h3>
     <div th:if="${errorMessage}" class="error-box" th:text="${errorMessage}">에러 메시지</div>
     <div class="comment-write" style="margin-bottom: 40px;">
         <form th:action="@{/posts/{postId}/comments(postId=${post.postId})}" th:object="${commentRequestDTO}" method="post">
-            <input type="hidden" th:name="_csrf" th:value="${_csrf?.token}" />
             <textarea th:field="*{content}" required placeholder="따뜻한 댓글을 남겨주세요."
                       style="width: 100%; height: 100px; background: #121a35; color: white; border: 1px solid #3d4450; border-radius: 10px; padding: 15px; resize: none;"></textarea>
             <div style="text-align: right; margin-top: 10px;">
@@ -86,23 +78,15 @@
         </div>
     </div>
 </div>
-
-<div class="container" th:if="${post.postIsNotice}" style="margin-top: 50px; border-top: 1px solid #3d4450; padding-top: 30px; text-align: center;">
-    <div style="background: #1e1e2d; padding: 20px; border-radius: 10px; color: #7ee0ff;">📢 <strong>안내:</strong> 공지사항에는 댓글을 작성할 수 없습니다.</div>
-</div>
-
 <script th:inline="javascript">
     function openReportModal(targetType, targetNo) {
         const reason = prompt("신고 사유를 입력해주세요:");
         if (!reason || reason.trim() === "") return;
-        const token = document.querySelector('input[name="_csrf"]')?.value;
         fetch('/api/reports', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': token },
+            headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ targetType: targetType, targetNo: targetNo, reason: reason })
-        })
-            .then(response => { if (response.ok) alert("신고가 정상적으로 접수되었습니다."); else alert("신고 접수에 실패했습니다."); })
-            .catch(err => alert("오류가 발생했습니다."));
+        }).then(response => { if (response.ok) alert("신고 접수되었습니다."); else alert("실패했습니다."); });
     }
 </script>
 </body>

--- a/src/main/resources/templates/community/post_update.html
+++ b/src/main/resources/templates/community/post_update.html
@@ -9,18 +9,30 @@
         .container { width: 800px; margin: 0 auto; padding: 60px 20px; }
         .post-card { background: #121a35; padding: 40px; border-radius: 20px; box-shadow: 0 10px 30px rgba(0,0,0,0.5); }
         .post-header { border-bottom: 1px solid #1a2447; margin-bottom: 20px; padding-bottom: 20px; }
-        .post-title { font-size: 28px; color: #7ee0ff; margin: 0 0 10px 0; width: 100%; background: #1a2447; border: 1px solid #5f7cff; border-radius: 8px; padding: 10px; color: #7ee0ff; }
-        .post-content { line-height: 1.8; font-size: 16px; min-height: 300px; width: 100%; background: #1a2447; border: 1px solid #5f7cff; border-radius: 8px; padding: 15px; color: #f5f7ff; resize: none; }
+        /* input과 textarea에 box-sizing 추가해서 레이아웃 깨짐 방지 */
+        .post-title { font-size: 28px; color: #7ee0ff; margin: 0 0 10px 0; width: 100%; background: #1a2447; border: 1px solid #5f7cff; border-radius: 8px; padding: 10px; color: #7ee0ff; box-sizing: border-box; }
+        .post-content { line-height: 1.8; font-size: 16px; min-height: 300px; width: 100%; background: #1a2447; border: 1px solid #5f7cff; border-radius: 8px; padding: 15px; color: #f5f7ff; resize: none; box-sizing: border-box; }
         .btn-area { margin-top: 30px; text-align: center; }
         .btn { display: inline-block; padding: 12px 25px; border-radius: 8px; background: #5f7cff; color: white; text-decoration: none; font-weight: bold; margin: 0 5px; border: none; cursor: pointer; }
         .btn-list { background: #1d295f; }
         label { display: block; margin-bottom: 10px; color: #b8c1e7; font-weight: bold; }
+
+        /* ★ 에러 메시지 박스 스타일 추가 ★ */
+        .error-box {
+            margin-bottom: 20px; padding: 12px 16px;
+            background: #2a1212; border: 1px solid #ff6b6b;
+            color: #ffb4b4; border-radius: 8px; font-size: 14px;
+        }
     </style>
 </head>
 <body>
 <div class="container">
+    <div th:if="${errorMessage}" class="error-box" th:text="${errorMessage}">
+        비속어가 포함되어 있습니다.
+    </div>
+
     <div class="post-card">
-        <form th:action="@{/continents/posts/edit/{id}(id=${post.postId})}" method="post">
+        <form th:action="@{/continents/posts/edit/{id}(id=${postId})}" method="post">
             <div class="post-header">
                 <label>게시글 제목 수정</label>
                 <input type="text" name="postTitle" th:value="${post.title}" class="post-title">
@@ -33,7 +45,7 @@
 
             <div class="btn-area">
                 <button type="submit" class="btn">수정완료</button>
-                <a th:href="@{/posts/{id}(id=${post.postId})}" class="btn btn-list">취소</a>
+                <a th:href="@{/posts/{id}(id=${postId})}" class="btn btn-list">취소</a>
             </div>
         </form>
     </div>

--- a/src/main/resources/templates/community/posts.html
+++ b/src/main/resources/templates/community/posts.html
@@ -15,8 +15,6 @@
     .btn-write { background: #ffb648; color: #1d1d1d; }
     .empty-msg { text-align: center; padding: 50px; color: #b8c1e7; }
     a { color: inherit; text-decoration: none; }
-
-    /* 공지사항 전용 스타일 */
     .notice-row { background: rgba(233, 182, 236, 0.05); border-left: 4px solid #e9b6ec; }
     .notice-badge { background: #ff5f5f; color: white; padding: 2px 6px; border-radius: 4px; font-size: 11px; margin-right: 8px; vertical-align: middle; font-weight: bold; }
     .notice-text { color: #e9b6ec !important; font-weight: bold; }
@@ -28,41 +26,44 @@
     <h1>대륙 <span th:text="${continentId}">1</span> 게시판</h1>
     <a th:href="@{/}" class="btn">← 메인으로</a>
   </div>
-
   <div class="section">
     <table class="board-table">
       <thead>
       <tr>
-        <th style="width: 15%;">작성일</th> <th style="width: 55%;">제목</th>
-        <th style="width: 30%;">작성자</th>
+        <th style="width: 15%;">작성일</th> <th style="width: 50%;">제목</th>
+        <th style="width: 35%;">작성자</th>
       </tr>
       </thead>
       <tbody>
       <tr th:each="post : ${posts}"
           th:onclick="|location.href='/posts/${post.postId}'|"
           th:classappend="${post.postIsNotice} ? 'notice-row' : ''">
-
         <td th:text="${post.postIsNotice} ? '공지' : ${post.createdAt}"
             th:classappend="${post.postIsNotice} ? 'notice-text' : ''"
             style="color: #b8c1e7; font-size: 14px;">2026-04-17</td>
-
         <td>
           <span th:if="${post.postIsNotice}" class="notice-badge">공지</span>
           <a th:href="@{/posts/{id}(id=${post.postId})}"
              th:text="${post.title}"
              th:classappend="${post.postIsNotice} ? 'notice-text' : ''">게시글 제목</a>
         </td>
-
-        <td th:text="${post.authorName}">작성자 이름</td>
+        <td>
+          <span th:text="${post.authorName}">작성자</span>
+          <span th:if="${post.authorRankComment}"
+                th:text="'(' + ${post.authorRankComment} + ')'"
+                th:style="${post.authorRank == 'REPTILIAN'}
+                          ? 'color: #FFD700; font-weight: bold; text-shadow: 0 0 5px rgba(255, 215, 0, 0.5); font-size: 12px; margin-left: 3px;'
+                          : (${post.authorRank == 'NOVICE'}
+                             ? 'color: #708090; font-style: italic; font-size: 11px; margin-left: 3px;'
+                             : 'color: #b8c1e7; font-size: 12px; margin-left: 3px;')"></span>
+        </td>
       </tr>
-
       <tr th:if="${#lists.isEmpty(posts)}">
         <td colspan="3" class="empty-msg">게시글이 존재하지 않습니다.</td>
       </tr>
       </tbody>
     </table>
   </div>
-
   <div style="margin-top: 20px; text-align: right;">
     <a th:href="@{/continents/{id}/posts/new(id=${continentId})}" class="btn btn-write">새 글 쓰기</a>
   </div>


### PR DESCRIPTION
## 관련 이슈
Closes #199 

## 작업 브랜치
- ex) feature/community-0420

## 작업 목적
- 게시글을 수정할 때도 비속어를 포함하지 못하도록 했다.
- 사용자가 게시글을 작성하면 그 이름 옆에 계급이 뜨게 수정했다.

## 변경 사항
- post detail html, posts.html


### 상세 변경 내용


## 테스트 내용
- [ ] 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] 로컬 실행 확인

