### PR TITLE
fix:비회원이 이미지 접근 허용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,7 @@ src/main/resources/gcs/
 ### 업로드된 이미지 파일 제외 (폴더는 유지) ###
 src/main/resources/static/images/profile/*
 src/main/resources/static/images/courseThumbnail/*
+src/main/resources/static/images/continentThumbnail/*
 !src/main/resources/static/images/profile/.gitkeep
 !src/main/resources/static/images/courseThumbnail/.gitkeep
+!src/main/resources/static/images/continentThumbnail/.gitkeep

--- a/src/main/java/com/wanted/ailienlmsprogram/global/config/SecurityConfig.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/global/config/SecurityConfig.java
@@ -51,7 +51,18 @@ public class SecurityConfig {
                 .authenticationProvider(authenticationProvider())
                 //사용자별 접근 권한
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/", "/login", "/signup", "/access-denied", "/continents", "/continents/*").permitAll()
+                        .requestMatchers(
+                                "/",
+                                "/login",
+                                "/signup",
+                                "/access-denied",
+                                "/continents",
+                                "/continents/*",
+                                "/images/**",
+                                "/css/**",
+                                "/js/**",
+                                "/favicon.ico"
+                        ).permitAll()
                         .requestMatchers("/continents/*/posts", "/courses/*").authenticated()
                         .requestMatchers("/main").hasRole("STUDENT")
                         .requestMatchers("/student/**").hasRole("STUDENT")


### PR DESCRIPTION
## 관련 이슈
Closes #203 

## 작업 브랜치
- fix/continent-image

## 작업 목적
- 시연 시에 대륙이미지가 잘 보일 수 있도록 수정

## 변경 사항
- securityConfig에서 /images에 대한 접근을 허용시킴, 이외 gitignore images/continentThumbnails 추가



## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

