### PR TITLE
일부 service 로직에 권한확인 로직 추가

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/coursecommand/controller/CourseCommandController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursecommand/controller/CourseCommandController.java
@@ -116,9 +116,11 @@ public class CourseCommandController {
     @PostMapping("/instructor/courses/{courseId}/edit")
     public String editMyCourse(@RequestParam(value = "thumbnailFile", required = false) MultipartFile thumbnailFile,
                                @PathVariable Long courseId,
-                               @ModelAttribute CourseApplyDTO request) throws IOException {
+                               @ModelAttribute CourseApplyDTO request,
+                               @AuthenticationPrincipal CustomUserDetails userDetails) throws IOException {
 
-        courseCommandService.editMyCourse(thumbnailFile, courseId,request);
+        Long memberId = userDetails.getMember().getMemberId();
+        courseCommandService.editMyCourse(thumbnailFile, courseId, memberId, request);
 
         return "redirect:/instructor/courses/PUBLISHED";
     }

--- a/src/main/java/com/wanted/ailienlmsprogram/coursecommand/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursecommand/service/CourseCommandService.java
@@ -131,10 +131,15 @@ public class CourseCommandService {
     }
 
     @Transactional
-    public void editMyCourse(MultipartFile thumbnailFile, Long courseId, CourseApplyDTO request) throws IOException {
+    public void editMyCourse(MultipartFile thumbnailFile, Long courseId, Long memberId, CourseApplyDTO request) throws IOException {
 
         Course course = courseRepository.findById(courseId)
                                         .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강좌입니다."));
+
+        // 본인 소유 강좌인지 확인
+        if (!course.getInstructor().getMemberId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인의 강좌만 수정할 수 있습니다.");
+        }
 
         Continent continent = continentRepository.getReferenceById(request.getContinentId());
 

--- a/src/main/java/com/wanted/ailienlmsprogram/coursenotice/controller/CourseNoticeController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursenotice/controller/CourseNoticeController.java
@@ -78,9 +78,11 @@ public class CourseNoticeController {
     @PostMapping("/instructor/courses/{courseId}/notices/{noticeId}/edit")
     public String editNotice(@ModelAttribute CourseNoticeApplyDTO request,
                              @PathVariable Long courseId,
-                             @PathVariable Long noticeId) {
+                             @PathVariable Long noticeId,
+                             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        courseNoticeService.editNotice(request, noticeId);
+        Long memberId = userDetails.getMember().getMemberId();
+        courseNoticeService.editNotice(request, noticeId, memberId);
 
         return "redirect:/instructor/courses/" + courseId + "/notices";
     }
@@ -102,9 +104,11 @@ public class CourseNoticeController {
     // ===== 삭제 처리 =====
     @PostMapping("/instructor/courses/{courseId}/notices/{noticeId}/delete")
     public String deleteNotice(@PathVariable Long courseId,
-                               @PathVariable Long noticeId) {
+                               @PathVariable Long noticeId,
+                               @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        courseNoticeService.deleteNotice(noticeId);
+        Long memberId = userDetails.getMember().getMemberId();
+        courseNoticeService.deleteNotice(noticeId, memberId);
 
         return "redirect:/instructor/courses/" + courseId + "/notices";
     }

--- a/src/main/java/com/wanted/ailienlmsprogram/coursenotice/service/CourseNoticeService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursenotice/service/CourseNoticeService.java
@@ -94,15 +94,18 @@ public class CourseNoticeService {
     // ===== 수정 =====
 
     @Transactional
-    public void editNotice(CourseNoticeApplyDTO request, Long noticeId) {
+    public void editNotice(CourseNoticeApplyDTO request, Long noticeId, Long memberId) {
 
         // 1. 공지사항 조회
         CourseNotice notice = courseNoticeRepository.findById(noticeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 공지사항입니다."));
 
-        // 2. 엔티티 수정 메서드 호출
-        //    → @Transactional + 더티체킹으로 save() 없이 자동 UPDATE
-        //    → editNotice() 내부에서 updatedAt 자동 갱신
+        // 2. 본인이 작성한 공지사항인지 확인
+        if (!notice.getAuthor().getMemberId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인이 작성한 공지사항만 수정할 수 있습니다.");
+        }
+
+        // 3. 엔티티 수정 메서드 호출
         notice.editNotice(
                 request.getCourseNoticeTitle(),
                 request.getCourseNoticeContent()
@@ -112,13 +115,18 @@ public class CourseNoticeService {
     // ===== 삭제 =====
 
     @Transactional
-    public void deleteNotice(Long noticeId) {
+    public void deleteNotice(Long noticeId, Long memberId) {
 
         // 1. 공지사항 조회
         CourseNotice notice = courseNoticeRepository.findById(noticeId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 공지사항입니다."));
 
-        // 2. DB에서 삭제
+        // 2. 본인이 작성한 공지사항인지 확인
+        if (!notice.getAuthor().getMemberId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인이 작성한 공지사항만 삭제할 수 있습니다.");
+        }
+
+        // 3. DB에서 삭제
         courseNoticeRepository.delete(notice);
     }
 

--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/controller/LectureController.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/controller/LectureController.java
@@ -137,8 +137,10 @@ public class LectureController {
 
     @GetMapping("/instructor/courses/{courseId}/lectures/{lectureId}/delete")
     public String deleteLecture(@PathVariable Long courseId,
-                                @PathVariable Long lectureId) {
-        lectureService.deleteLecture(lectureId);
+                                @PathVariable Long lectureId,
+                                @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long memberId = userDetails.getMember().getMemberId();
+        lectureService.deleteLecture(lectureId, memberId);
 
         return "redirect:/instructor/courses/" + courseId + "/lectures";
     }

--- a/src/main/java/com/wanted/ailienlmsprogram/lecture/service/LectureService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/lecture/service/LectureService.java
@@ -117,6 +117,11 @@ public class LectureService {
         Lecture lecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강의입니다."));
 
+        // 2. 본인 소유 강좌의 강의인지 확인
+        if (!lecture.getCourse().getInstructor().getMemberId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인의 강의만 수정할 수 있습니다.");
+        }
+
         // 2. 제목/설명 먼저 DB 업데이트 (더티체킹)
         //    videoUrl은 비동기 완료 후 업데이트되므로 여기선 건드리지 않음
         lecture.editLectureInfo(
@@ -150,13 +155,18 @@ public class LectureService {
     }
 
     @Transactional
-    public void deleteLecture(Long lectureId) {
+    public void deleteLecture(Long lectureId, Long memberId) {
 
         // 1. 강의 조회
         Lecture lecture = lectureRepository.findById(lectureId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "존재하지 않는 강의입니다."));
 
-        // 2. GCS 영상 삭제 (영상이 있을 때만) → LectureAsyncService에 위임
+        // 2. 본인 소유 강좌의 강의인지 확인
+        if (!lecture.getCourse().getInstructor().getMemberId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인의 강의만 삭제할 수 있습니다.");
+        }
+
+        // 3. GCS 영상 삭제 (영상이 있을 때만) → LectureAsyncService에 위임
         lectureAsyncService.deleteVideoFile(lecture.getVideoUrl());
 
         lectureRepository.deleteById(lectureId);


### PR DESCRIPTION
## 관련 이슈
Closes #209 

## 작업 브랜치
- refactor/ownershipCheck

## 작업 목적
- 본인의 강좌(공지사항/qna)만 수정가능

## 변경 사항
- lecture 패키지 — Service / Controller
- coursecommand 패키지 — Service / Controller
- coursenotice 패키지 — Service / Controller

### 상세 변경 내용

#### lecture 패키지 — Service / Controller
1. `LectureService.editLecture()` — 본인 소유 강좌의 강의인지 확인 로직 추가
2. `LectureService.deleteLecture()` — memberId 파라미터 추가, 본인 소유 강좌의 강의인지 확인 로직 추가
3. `LectureController.deleteLecture()` — @AuthenticationPrincipal 추가, memberId 추출 후 서비스에 전달

#### coursecommand 패키지 — Service / Controller
4. `CourseCommandService.editMyCourse()` — memberId 파라미터 추가, 본인 소유 강좌인지 확인 로직 추가
5. `CourseCommandController.editMyCourse()` — @AuthenticationPrincipal 추가, memberId 추출 후 서비스에 전달

#### coursenotice 패키지 — Service / Controller
6. `CourseNoticeService.editNotice()` — memberId 파라미터 추가, 본인이 작성한 공지사항인지 확인 로직 추가
7. `CourseNoticeService.deleteNotice()` — memberId 파라미터 추가, 본인이 작성한 공지사항인지 확인 로직 추가
8. `CourseNoticeController.editNotice()` — @AuthenticationPrincipal 추가, memberId 추출 후 서비스에 전달
9. `CourseNoticeController.deleteNotice()` — @AuthenticationPrincipal 추가, memberId 추출 후 서비스에 전달

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

