### PR TITLE
Refactor : 신고 시점 스냅샷 저장 로직 구현

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/community/entity/CommunityComment.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/entity/CommunityComment.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-//@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "continent_comment")

--- a/src/main/java/com/wanted/ailienlmsprogram/community/entity/Report.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/entity/Report.java
@@ -3,6 +3,7 @@ package com.wanted.ailienlmsprogram.community.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,15 +28,30 @@ public class Report {
     @Column(name = "report_reason", columnDefinition = "TEXT")
     private String reason;
 
+    // --- 신고 당시의 데이터를 보존하기 위한 스냅샷 필드 ---
+    @Column(name = "reported_title")
+    private String reportedTitle;
+
+    @Column(name = "reported_content", columnDefinition = "TEXT")
+    private String reportedContent;
+    // ------------------------------------------------
+
     @Column(name = "created_at")
     private LocalDateTime reportDate = LocalDateTime.now();
 
-    public static Report create(Long reporterNo, TargetType targetType, Long targetNo, String reason) {
+    /**
+     * 신고 생성 메서드
+     * @param title 신고 시점의 제목 (댓글일 경우 보통 null 또는 기본값)
+     * @param content 신고 시점의 원본 내용 (박제용)
+     */
+    public static Report create(Long reporterNo, TargetType targetType, Long targetNo, String reason, String title, String content) {
         Report report = new Report();
         report.reporterNo = reporterNo;
         report.targetType = targetType;
         report.targetNo = targetNo;
         report.reason = reason;
+        report.reportedTitle = title;
+        report.reportedContent = content;
         return report;
     }
 }

--- a/src/main/java/com/wanted/ailienlmsprogram/community/service/ReportService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/community/service/ReportService.java
@@ -1,7 +1,11 @@
 package com.wanted.ailienlmsprogram.community.service;
 
+import com.wanted.ailienlmsprogram.community.entity.CommunityComment;
+import com.wanted.ailienlmsprogram.community.entity.CommunityPost;
 import com.wanted.ailienlmsprogram.community.entity.Report;
 import com.wanted.ailienlmsprogram.community.entity.TargetType;
+import com.wanted.ailienlmsprogram.community.repository.CommentRepository;
+import com.wanted.ailienlmsprogram.community.repository.PostRepository;
 import com.wanted.ailienlmsprogram.community.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,10 +17,43 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReportService {
 
     private final ReportRepository reportRepository;
+    private final PostRepository postRepository;       // 게시글 조회를 위해 추가
+    private final CommentRepository commentRepository; // 댓글 조회를 위해 추가
 
     public void createReport(Long reporterNo, String targetType, Long targetNo, String reason) {
-        Report report = Report.create(reporterNo, TargetType.valueOf(targetType), targetNo, reason);
+        String reportedTitle = null;
+        String reportedContent = null;
+        TargetType type = TargetType.valueOf(targetType);
 
+        // 1. 신고 대상이 게시글(POST)일 경우
+        if (type == TargetType.CONTINENT_POST) {
+            CommunityPost post = postRepository.findById(targetNo)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 게시글을 찾을 수 없습니다. ID: " + targetNo));
+
+            // 신고 즉시 제목과 내용을 변수에 담기 (박제 준비)
+            reportedTitle = post.getPostTitle();
+            reportedContent = post.getPostContent();
+        }
+        // 2. 신고 대상이 댓글(COMMENT)일 경우
+        else if (type == TargetType.CONTINENT_COMMENT) {
+            CommunityComment comment = commentRepository.findById(targetNo)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 댓글을 찾을 수 없습니다. ID: " + targetNo));
+
+            reportedTitle = "댓글 신고입니다."; // 댓글은 제목이 없으므로 고정 문구
+            reportedContent = comment.getContent(); // CommunityComment의 필드명인 content 사용
+        }
+
+        // 3. 수정한 Report.create 메서드에 박제할 내용까지 담아서 생성
+        Report report = Report.create(
+                reporterNo,
+                type,
+                targetNo,
+                reason,
+                reportedTitle,
+                reportedContent
+        );
+
+        // 4. DB에 저장 (이제 스냅샷이 함께 저장됩니다!)
         reportRepository.save(report);
     }
 }


### PR DESCRIPTION
## 관련 이슈
Closes #214 

## 작업 브랜치
- ex) feat/community-0416

## 작업 목적
- 사용자가 부적절한 게시글을 신고했을 때의 글 제목과 내용을 저장 -> 작성자가 내용을 수정해도 관리자가 원래 내용을 보고 조치가 가능

## 변경 사항
- ReportService

### 상세 변경 내용
1.

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

