### PR TITLE
feat: 신고 시점 데이터 스냅샷 저장 및 관리자 상세 조회 연동

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminReportQueryRepository.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/admin/repository/AdminReportQueryRepository.java
@@ -215,8 +215,8 @@ public class AdminReportQueryRepository {
                 .targetMemberName(targetMember != null ? targetMember.getName() : null)
                 .categoryLabel("대륙")
                 .categoryValue(continent != null ? continent.getContinentName() : null)
-                .targetTitle(post.getPostTitle())
-                .targetContent(post.getPostContent())
+                .targetTitle(report.getReportedTitle())     // post.getPostTitle() 대신 이거로!
+                .targetContent(report.getReportedContent()) // post.getPostContent() 대신 이거로!
                 .parentTitle(null)
                 .targetDeleted(post.isPostIsDeleted())
                 .build();
@@ -247,7 +247,7 @@ public class AdminReportQueryRepository {
                 .categoryLabel("대륙")
                 .categoryValue(continent != null ? continent.getContinentName() : null)
                 .targetTitle("댓글")
-                .targetContent(comment.getContent())
+                .targetContent(report.getReportedContent())
                 .parentTitle(parentPost != null ? parentPost.getPostTitle() : null)
                 .targetDeleted(comment.isDeleted())
                 .build();


### PR DESCRIPTION
## 관련 이슈
Closes #216 

## 작업 브랜치
- ex) feat/community-0420

## 작업 목적
- 댓글을 삭제해도 관리자가 원본 내용을 확인 가능
- 관리자 페이지에서 원본 게시글, 댓글 확인 가능

## 변경 사항
- AdminReportQueryRepository

### 상세 변경 내용
1. 

## 테스트 내용
- [ ] 정상 동작 확인
- [ ] 예외 케이스 확인
- [ ] 로컬 실행 확인

