### PR TITLE
버그 수정 및 html 기능 추가

### DIFF
--- a/src/main/java/com/wanted/ailienlmsprogram/coursecommand/service/CourseCommandService.java
+++ b/src/main/java/com/wanted/ailienlmsprogram/coursecommand/service/CourseCommandService.java
@@ -94,9 +94,6 @@ public class CourseCommandService {
             course.setInstructorName(foundCourse.getInstructor().getName());
         }
 
-        // 테스트 로직입니다
-        course.setCourseDescription("지구를 정복하기 위한 최고의 자바 강의! 일루미나티도 수강 중입니다.");
-
         return course;
     }
 

--- a/src/main/resources/templates/answer/detail.html
+++ b/src/main/resources/templates/answer/detail.html
@@ -61,16 +61,20 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>
     </div>
 
     <nav class="flex-1 py-6">
-        <a href="#" class="flex items-center gap-4 text-cyan-400 bg-cyan-400/10 border-r-4 border-cyan-400 py-3.5 px-6 font-label">
+        <a th:href="@{/instructor}" class="flex items-center gap-4 text-cyan-400 bg-cyan-400/10 border-r-4 border-cyan-400 py-3.5 px-6 font-label">
             <span class="material-symbols-outlined">satellite_alt</span>
             <span class="text-sm tracking-wide">사령부 대시보드</span>
+        </a>
+        <a th:href="@{/}" class="flex items-center gap-4 text-slate-400 hover:text-cyan-400 hover:bg-cyan-400/5 py-3.5 px-6 transition-all font-label">
+            <span class="material-symbols-outlined">public</span>
+            <span class="text-sm tracking-wide">대륙 탐색</span>
         </a>
     </nav>
 

--- a/src/main/resources/templates/community/post_create.html
+++ b/src/main/resources/templates/community/post_create.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="dark" lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html class="dark" lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -101,7 +101,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>
@@ -118,7 +118,20 @@
             <span class="text-sm font-label font-bold tracking-wide">대륙 탐색</span>
         </a>
 
-        <a th:href="@{/student}"
+        <!-- 강사: 강사 홈 -->
+        <a sec:authorize="hasRole('INSTRUCTOR')" th:href="@{/instructor}"
+           class="flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-cyan-400 bg-cyan-400/10 border-r-4 border-cyan-400">
+            <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">satellite_alt</span>
+            <span class="text-sm font-label font-bold tracking-wide">강사 홈</span>
+        </a>
+
+        <!-- 관리자: 관리자 홈 / 일반 사용자: 학생 홈 -->
+        <a sec:authorize="hasRole('ADMIN')" th:href="@{/admin}"
+           class="flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-cyan-400 bg-cyan-400/10 border-r-4 border-cyan-400">
+            <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">admin_panel_settings</span>
+            <span class="text-sm font-label font-bold tracking-wide">관리자 홈</span>
+        </a>
+        <a sec:authorize="hasRole('STUDENT')" th:href="@{/student}"
            class="flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-cyan-400 bg-cyan-400/10 border-r-4 border-cyan-400">
             <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">rocket_launch</span>
             <span class="text-sm font-label font-bold tracking-wide">학생 홈</span>

--- a/src/main/resources/templates/community/post_update.html
+++ b/src/main/resources/templates/community/post_update.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="dark" lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html class="dark" lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -88,7 +88,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>
@@ -105,7 +105,20 @@
             <span class="text-sm font-label font-bold tracking-wide">대륙 탐색</span>
         </a>
 
-        <a th:href="@{/student}"
+        <!-- 강사: 강사 홈 -->
+        <a sec:authorize="hasRole('INSTRUCTOR')" th:href="@{/instructor}"
+           class="flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-cyan-400 bg-cyan-400/10 border-r-4 border-cyan-400">
+            <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">satellite_alt</span>
+            <span class="text-sm font-label font-bold tracking-wide">강사 홈</span>
+        </a>
+
+        <!-- 관리자: 관리자 홈 / 일반 사용자: 학생 홈 -->
+        <a sec:authorize="hasRole('ADMIN')" th:href="@{/admin}"
+           class="flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-cyan-400 bg-cyan-400/10 border-r-4 border-cyan-400">
+            <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">admin_panel_settings</span>
+            <span class="text-sm font-label font-bold tracking-wide">관리자 홈</span>
+        </a>
+        <a sec:authorize="hasRole('STUDENT')" th:href="@{/student}"
            class="flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-cyan-400 bg-cyan-400/10 border-r-4 border-cyan-400">
             <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">rocket_launch</span>
             <span class="text-sm font-label font-bold tracking-wide">학생 홈</span>

--- a/src/main/resources/templates/continent/detail.html
+++ b/src/main/resources/templates/continent/detail.html
@@ -79,7 +79,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>
@@ -96,7 +96,20 @@
             <span class="text-sm font-label font-bold tracking-wide">대륙 탐색</span>
         </a>
 
-        <a th:href="@{/student}" data-menu="student"
+        <!-- 강사: 강사 홈 -->
+        <a sec:authorize="hasRole('INSTRUCTOR')" th:href="@{/instructor}"
+           class="menu-item flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-slate-500 hover:bg-white/5 hover:text-slate-300">
+            <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">satellite_alt</span>
+            <span class="text-sm font-label font-bold tracking-wide">강사 홈</span>
+        </a>
+
+        <!-- 관리자: 관리자 홈 / 일반 사용자: 학생 홈 -->
+        <a sec:authorize="hasRole('ADMIN')" th:href="@{/admin}" data-menu="student"
+           class="menu-item flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-slate-500 hover:bg-white/5 hover:text-slate-300">
+            <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">admin_panel_settings</span>
+            <span class="text-sm font-label font-bold tracking-wide">관리자 홈</span>
+        </a>
+        <a sec:authorize="hasRole('STUDENT')" th:href="@{/student}" data-menu="student"
            class="menu-item flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-slate-500 hover:bg-white/5 hover:text-slate-300">
             <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">rocket_launch</span>
             <span class="text-sm font-label font-bold tracking-wide">학생 홈</span>

--- a/src/main/resources/templates/course/apply.html
+++ b/src/main/resources/templates/course/apply.html
@@ -104,6 +104,10 @@
             <span class="material-symbols-outlined">library_books</span>
             <span class="text-sm tracking-wide uppercase">My Archive</span>
         </a>
+        <a th:href="@{/}" class="flex items-center gap-4 text-slate-400 hover:text-cyan-400 hover:bg-cyan-400/5 py-3.5 px-6 transition-all font-label">
+            <span class="material-symbols-outlined">public</span>
+            <span class="text-sm tracking-wide uppercase">대륙 탐색</span>
+        </a>
     </nav>
 
     <div class="p-6 mt-auto">

--- a/src/main/resources/templates/course/detail.html
+++ b/src/main/resources/templates/course/detail.html
@@ -95,7 +95,7 @@
         <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
         <div class="flex items-center gap-1">
           <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-          <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+          <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
         </div>
       </div>
     </div>
@@ -107,7 +107,7 @@
       <div class="px-6 mb-4">
         <span class="text-[9px] font-label font-black text-amber-500 uppercase tracking-[0.3em]">Command Protocol</span>
       </div>
-      <a th:href="@{/instructor/dashboard}"
+      <a th:href="@{/instructor}"
          class="flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-cyan-400 bg-cyan-400/10 border-r-4 border-cyan-400">
         <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">satellite_alt</span>
         <span class="text-sm font-label font-bold tracking-wide">사령부 대시보드</span>
@@ -125,7 +125,13 @@
         <span class="text-sm font-label font-bold tracking-wide">대륙 탐색</span>
       </a>
 
-      <a th:href="@{/student}" data-menu="student"
+      <!-- 관리자: 관리자 홈 / 일반 사용자: 학생 홈 -->
+      <a sec:authorize="hasRole('ADMIN')" th:href="@{/admin}" data-menu="student"
+         class="menu-item flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-slate-500 hover:bg-white/5 hover:text-slate-300">
+        <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">admin_panel_settings</span>
+        <span class="text-sm font-label font-bold tracking-wide">관리자 홈</span>
+      </a>
+      <a sec:authorize="hasRole('STUDENT')" th:href="@{/student}" data-menu="student"
          class="menu-item flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-slate-500 hover:bg-white/5 hover:text-slate-300">
         <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">rocket_launch</span>
         <span class="text-sm font-label font-bold tracking-wide">학생 홈</span>
@@ -165,10 +171,10 @@
   <div class="max-w-6xl mx-auto">
 
     <div class="mb-8 flex items-center justify-between">
-      <a th:href="@{/student/enrollments}"
-         class="flex items-center gap-2 text-[10px] font-label tracking-widest text-slate-500 hover:text-primary transition-all uppercase group">
+      <a onclick="history.back()"
+         class="flex items-center gap-2 text-[10px] font-label tracking-widest text-slate-500 hover:text-primary transition-all uppercase group cursor-pointer">
         <span class="material-symbols-outlined text-sm transition-transform group-hover:-translate-x-1">arrow_back</span>
-        Return to Mission List
+        Return to Previous
       </a>
     </div>
 
@@ -291,12 +297,12 @@
               <div class="h-12 w-12 rounded-xl bg-primary/10 flex items-center justify-center border border-primary/20 text-2xl">👤</div>
               <div>
                 <div class="text-sm font-headline font-bold text-white tracking-tight" sec:authentication="name">요원명</div>
-                <div class="text-[10px] font-label text-slate-500 uppercase tracking-widest">Rank: <span class="text-secondary" th:text="${#authentication.principal.member.rank}">RANK</span></div>
+                <div class="text-[10px] font-label text-slate-500 uppercase tracking-widest">Rank: <span class="text-secondary" th:text="${loginMember?.rank}">RANK</span></div>
               </div>
             </div>
 
             <!-- MINERVAL -->
-            <div th:if="${#authentication.principal.member.rank.name() == 'MINERVAL'}"
+            <div th:if="${loginMember?.rank != null and loginMember.rank.name() == 'MINERVAL'}"
                  style="background:#06091a;border:1px solid rgba(95,124,255,0.3);border-radius:16px;padding:16px 14px;position:relative;overflow:hidden;display:grid;grid-template-columns:70px 1fr;gap:14px;align-items:center;margin:16px 0;font-family:'Courier New',monospace;">
               <style>
                 @keyframes minRingRotate { from{transform:rotate(0deg)} to{transform:rotate(360deg)} }
@@ -337,7 +343,7 @@
               </div>
             </div>
 
-            <div th:if="${#authentication.principal.member.rank.name() == 'NOVICE'}"
+            <div th:if="${loginMember?.rank != null and loginMember.rank.name() == 'NOVICE'}"
                  style="background:#06090f;border:1px solid rgba(255,95,95,0.22);border-radius:16px;padding:16px 14px;position:relative;overflow:hidden;margin:16px 0;font-family:'Courier New',monospace;">
               <style>
                 @keyframes novBlink2 { 0%,49%{opacity:1} 50%,100%{opacity:0} }
@@ -413,7 +419,7 @@
               </div>
             </div>
 
-            <div th:if="${#authentication.principal.member.rank.name() == 'REPTILIAN'}"
+            <div th:if="${loginMember?.rank != null and loginMember.rank.name() == 'REPTILIAN'}"
 
                  style="background: linear-gradient(145deg, #0b1020, #1a2238); border: 1px solid rgba(126, 224, 255, 0.3); padding: 16px; border-radius: 16px; margin: 16px 0; position: relative; display: grid; grid-template-columns: 70px 1fr; align-items: center; gap: 14px; overflow: hidden;">
 

--- a/src/main/resources/templates/course/edit.html
+++ b/src/main/resources/templates/course/edit.html
@@ -103,6 +103,10 @@
             <span class="material-symbols-outlined">person</span>
             <span class="text-sm tracking-wide uppercase">Profile Intel</span>
         </a>
+        <a th:href="@{/}" class="flex items-center gap-4 text-slate-400 hover:text-cyan-400 hover:bg-cyan-400/5 py-3.5 px-6 transition-all font-label">
+            <span class="material-symbols-outlined">public</span>
+            <span class="text-sm tracking-wide uppercase">대륙 탐색</span>
+        </a>
     </nav>
 
     <div class="p-6 mt-auto">

--- a/src/main/resources/templates/course/find.html
+++ b/src/main/resources/templates/course/find.html
@@ -120,6 +120,10 @@
             <span class="material-symbols-outlined">add_box</span>
             <span class="text-sm tracking-wide uppercase">New Mission</span>
         </a>
+        <a th:href="@{/}" class="flex items-center gap-4 text-slate-400 hover:text-cyan-400 hover:bg-cyan-400/5 py-3.5 px-6 transition-all font-label">
+            <span class="material-symbols-outlined">public</span>
+            <span class="text-sm tracking-wide uppercase">대륙 탐색</span>
+        </a>
     </nav>
     <div class="p-6 mt-auto">
         <div class="relative group cursor-help">

--- a/src/main/resources/templates/home/index.html
+++ b/src/main/resources/templates/home/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="dark" lang="ko" xmlns:th="http://www.thymeleaf.org">
+<html class="dark" lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -137,7 +137,20 @@
             <span class="text-sm font-label font-bold tracking-wide">대륙 탐색</span>
         </a>
 
-        <a th:href="@{/student}" data-menu="student"
+        <!-- 강사: 강사 홈 -->
+        <a sec:authorize="hasRole('INSTRUCTOR')" th:href="@{/instructor}"
+           class="menu-item flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-slate-500 hover:bg-white/5 hover:text-slate-300">
+            <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">satellite_alt</span>
+            <span class="text-sm font-label font-bold tracking-wide">강사 홈</span>
+        </a>
+
+        <!-- 관리자: 관리자 홈 / 일반 사용자: 학생 홈 -->
+        <a sec:authorize="hasRole('ADMIN')" th:href="@{/admin}" data-menu="student"
+           class="menu-item flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-slate-500 hover:bg-white/5 hover:text-slate-300">
+            <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">admin_panel_settings</span>
+            <span class="text-sm font-label font-bold tracking-wide">관리자 홈</span>
+        </a>
+        <a sec:authorize="hasRole('STUDENT')" th:href="@{/student}" data-menu="student"
            class="menu-item flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-slate-500 hover:bg-white/5 hover:text-slate-300">
             <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">rocket_launch</span>
             <span class="text-sm font-label font-bold tracking-wide">학생 홈</span>

--- a/src/main/resources/templates/instructor/edit.html
+++ b/src/main/resources/templates/instructor/edit.html
@@ -124,6 +124,10 @@
             <span class="material-symbols-outlined">edit_square</span>
             <span class="text-sm tracking-wide tracking-widest">Re-Configure</span>
         </div>
+        <a th:href="@{/}" class="flex items-center gap-4 text-slate-400 hover:text-cyan-400 hover:bg-cyan-400/5 py-3.5 px-6 transition-all font-label">
+            <span class="material-symbols-outlined">public</span>
+            <span class="text-sm tracking-wide uppercase">대륙 탐색</span>
+        </a>
     </nav>
     <div class="p-6 mt-auto">
         <div class="relative group cursor-help">

--- a/src/main/resources/templates/instructor/instructor-home.html
+++ b/src/main/resources/templates/instructor/instructor-home.html
@@ -91,7 +91,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>
@@ -101,6 +101,10 @@
         <a href="#" class="flex items-center gap-4 text-cyan-400 bg-cyan-400/10 border-r-4 border-cyan-400 py-3.5 px-6 font-label">
             <span class="material-symbols-outlined">satellite_alt</span>
             <span class="text-sm tracking-wide">사령부 대시보드</span>
+        </a>
+        <a th:href="@{/}" class="flex items-center gap-4 py-3.5 px-6 transition-all duration-200 group text-slate-500 hover:bg-white/5 hover:text-slate-300 font-label">
+            <span class="material-symbols-outlined text-xl group-hover:scale-110 transition-transform">public</span>
+            <span class="text-sm tracking-wide">대륙 탐색</span>
         </a>
     </nav>
 

--- a/src/main/resources/templates/instructor/profile.html
+++ b/src/main/resources/templates/instructor/profile.html
@@ -104,6 +104,10 @@
             <span class="material-symbols-outlined">person</span>
             <span class="text-sm tracking-wide tracking-widest uppercase">Intel Overview</span>
         </div>
+        <a th:href="@{/}" class="flex items-center gap-4 text-slate-400 hover:text-cyan-400 hover:bg-cyan-400/5 py-3.5 px-6 transition-all font-label">
+            <span class="material-symbols-outlined">public</span>
+            <span class="text-sm tracking-wide uppercase">대륙 탐색</span>
+        </a>
     </nav>
     <div class="p-6 mt-auto">
         <div class="relative group cursor-help">

--- a/src/main/resources/templates/lecture/add.html
+++ b/src/main/resources/templates/lecture/add.html
@@ -109,6 +109,10 @@
             <span class="material-symbols-outlined">library_books</span>
             <span class="text-sm tracking-wide tracking-widest uppercase font-bold">Course Assets</span>
         </a>
+        <a th:href="@{/}" class="flex items-center gap-4 text-slate-400 hover:text-cyan-400 hover:bg-cyan-400/5 py-3.5 px-6 transition-all font-label">
+            <span class="material-symbols-outlined">public</span>
+            <span class="text-sm tracking-wide uppercase">대륙 탐색</span>
+        </a>
     </nav>
 
     <div class="p-6 mt-auto">

--- a/src/main/resources/templates/lecture/edit.html
+++ b/src/main/resources/templates/lecture/edit.html
@@ -105,6 +105,10 @@
             <span class="material-symbols-outlined">library_books</span>
             <span class="text-sm tracking-wide tracking-widest uppercase font-bold">Course Assets</span>
         </a>
+        <a th:href="@{/}" class="flex items-center gap-4 text-slate-400 hover:text-cyan-400 hover:bg-cyan-400/5 py-3.5 px-6 transition-all font-label">
+            <span class="material-symbols-outlined">public</span>
+            <span class="text-sm tracking-wide uppercase">대륙 탐색</span>
+        </a>
     </nav>
 
     <div class="p-6 mt-auto">

--- a/src/main/resources/templates/lecture/find.html
+++ b/src/main/resources/templates/lecture/find.html
@@ -100,6 +100,10 @@
             <span class="material-symbols-outlined">person</span>
             <span class="text-sm tracking-wide uppercase">Profile Intel</span>
         </a>
+        <a th:href="@{/}" class="flex items-center gap-4 text-slate-400 hover:text-cyan-400 hover:bg-cyan-400/5 py-3.5 px-6 transition-all font-label">
+            <span class="material-symbols-outlined">public</span>
+            <span class="text-sm tracking-wide uppercase">대륙 탐색</span>
+        </a>
     </nav>
 
     <div class="p-6 mt-auto">

--- a/src/main/resources/templates/qna/list.html
+++ b/src/main/resources/templates/qna/list.html
@@ -59,7 +59,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/qna/modify.html
+++ b/src/main/resources/templates/qna/modify.html
@@ -101,7 +101,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/qna/write.html
+++ b/src/main/resources/templates/qna/write.html
@@ -95,7 +95,7 @@
         <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
         <div class="flex items-center gap-1">
           <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-          <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+          <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/student/cart.html
+++ b/src/main/resources/templates/student/cart.html
@@ -85,7 +85,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/student/edit.html
+++ b/src/main/resources/templates/student/edit.html
@@ -90,7 +90,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/student/enrollments.html
+++ b/src/main/resources/templates/student/enrollments.html
@@ -75,7 +75,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/student/notice-detail.html
+++ b/src/main/resources/templates/student/notice-detail.html
@@ -55,7 +55,7 @@
         <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
         <div class="flex items-center gap-1">
           <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-          <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+          <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/student/notice-list.html
+++ b/src/main/resources/templates/student/notice-list.html
@@ -79,7 +79,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/student/payment-detail.html
+++ b/src/main/resources/templates/student/payment-detail.html
@@ -73,7 +73,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/student/payment-list.html
+++ b/src/main/resources/templates/student/payment-list.html
@@ -75,7 +75,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/student/profile.html
+++ b/src/main/resources/templates/student/profile.html
@@ -75,7 +75,7 @@
                 <p class="text-xs font-headline font-black text-cyan-400 tracking-tight leading-none mb-1 uppercase" th:text="${loginMember.name}">OPERATIVE</p>
                 <div class="flex items-center gap-1">
                     <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse"></span>
-                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.role}|">RANK</p>
+                    <p class="text-[10px] font-label text-slate-500 font-bold tracking-tighter uppercase" th:text="|RANK: ${loginMember.rank}|">RANK</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## 관련 이슈
Closes #229 

## 작업 브랜치
-  refactor/html

## 작업 목적
- 버그 수정 및 기능 추가

## 변경 사항
- {templates} 패키지 — View (HTML)

### 상세 변경 내용
1. 공용 페이지 사이드바 — 권한별 홈 버튼 분기 추가
   - 대상 파일: `home/index.html`, `continent/detail.html`, `course/detail.html`, `community/post_create.html`, `community/post_update.html`
   - `sec:authorize="hasRole('INSTRUCTOR')"` 조건으로 강사 홈(`/instructor`) 버튼 추가
   - `sec:authorize="hasRole('ADMIN')"` 조건으로 관리자 홈(`/admin`) 버튼 추가
   - `sec:authorize="hasRole('STUDENT')"` 조건으로 학생 홈(`/student`) 버튼 표시
   - 기존 `!hasRole('ADMIN')` → `hasRole('STUDENT')` 로 조건 수정 (강사에게 학생 홈 버튼이 노출되던 문제 해결)
   - `course/detail.html` 기존 강사 분기의 잘못된 URL `/instructor/dashboard` → `/instructor` 수정

2. 공용 페이지 사이드바 — RANK 표시 오류 수정
   - 대상 파일: `answer/detail.html`, `student/enrollments.html`, `qna/modify.html`, `student/profile.html`, `community/post_update.html`, `continent/detail.html`, `qna/list.html`, `student/payment-detail.html`, `student/cart.html`, `instructor/instructor-home.html`, `qna/write.html`, `course/detail.html`, `community/post_create.html`, `student/payment-list.html`, `student/notice-detail.html`, `student/edit.html`, `student/notice-list.html` (총 17개)
   - 사이드바 RANK 표시가 `${loginMember.role}` 로 잘못 연결되어 `STUDENT`, `ADMIN` 등 역할(Role)이 표시되던 문제 수정
   - `${loginMember.role}` → `${loginMember.rank}` 로 교체

3. `course/detail.html` — 템플릿 파싱 오류 수정
   - 관리자가 `/courses/{id}` 접근 시 `rank` 필드가 `NULL`인 관리자 계정에서 `rank.name()` 호출로 `NullPointerException` 발생하던 문제 수정
   - 랭크 카드 `th:if` 조건 3곳에 null 체크 선행 조건 추가
   - 수정 전: `th:if="${#authentication.principal.member.rank.name() == 'MINERVAL'}"`
   - 수정 후: `th:if="${#authentication.principal.member.rank != null and #authentication.principal.member.rank.name() == 'MINERVAL'}"`

4. `course/detail.html` — 랭크 카드 실시간 반영 오류 수정
   - 수강 완료 후 랭크 업그레이드 시 강좌 상세 페이지의 랭크 카드가 즉시 반영되지 않던 문제 수정
   - `#authentication.principal.member.rank` (Spring Security 세션 캐시, 로그인 시점에 고정) → `${loginMember.rank}` (매 요청마다 DB 조회하는 `AuthMemberAdvice` 값) 로 교체

5. `course/detail.html` — Return 버튼 이전 페이지 이동으로 변경
   - 기존 `/student/enrollments` 하드코딩 URL로 인해 관리자 접근 시 권한 없음 오류 발생하던 문제 수정
   - `th:href="@{/student/enrollments}"` → `onclick="history.back()"` 으로 교체

6. 강사 전용 페이지 사이드바 — 대륙 탐색(`/`) 버튼 추가
   - 대상 파일: `instructor/instructor-home.html`, `instructor/profile.html`, `instructor/edit.html`, `lecture/find.html`, `lecture/edit.html`, `lecture/add.html`, `course/find.html`, `course/apply.html`, `course/edit.html`, `answer/detail.html` (총 10개)
   - 강사 전용 페이지에서 메인 페이지(`/`)로 이동하는 대륙 탐색 버튼 추가
   - `answer/detail.html` 사이드바의 `href="#"` (미구현 링크) → `th:href="@{/instructor}"` 로 수정

## 테스트 내용
- [x] 정상 동작 확인
- [x] 예외 케이스 확인
- [x] 로컬 실행 확인

